### PR TITLE
feat: map engine interface

### DIFF
--- a/src/essence/Basics/MapEngines/IMapEngine.ts
+++ b/src/essence/Basics/MapEngines/IMapEngine.ts
@@ -1,0 +1,264 @@
+import { LatLng, LatLngLike, PointLike, BoundsLike } from './types/geometry'
+import {
+    ViewState,
+    ViewOptions,
+    FlyToOptions,
+    FitBoundsOptions,
+    MapInitOptions,
+} from './types/view'
+import { LayerOptions } from './types/layers'
+import {
+    MapEventHandler,
+    MapEventOptions,
+    FeatureInteractionHandler,
+    FeaturePickResult,
+    QueryFeaturesOptions,
+} from './types/events'
+import { MapEngineType } from './types/engine'
+
+/**
+ * Core map engine contract.
+ *
+ * Every adapter (Leaflet, deck.gl) implements this.
+ * The interface is intentionally imperative for Leaflet compatibility.
+ * The deck.gl adapter translates imperative calls into declarative
+ * layer array updates internally.
+ *
+ * Coordinate convention: all methods accept LatLngLike which is an object
+ * with named lat/lng fields. Adapters convert to the engine's native
+ * coordinate order internally (Leaflet: [lat, lng], deck.gl: [lng, lat]).
+ *
+ * TNativeMap is the underlying map (L.Map, Deck, etc).
+ * TLayer is the engine's layer type.
+ * TEvent is the engine's event object.
+ */
+export interface IMapEngine<
+    TNativeMap = unknown,
+    TLayer = unknown,
+    TEvent = unknown,
+> {
+    /**
+     * Which engine this adapter represents.
+     */
+    readonly engineType: MapEngineType
+
+    /**
+     * Create the map inside the given container.
+     * deck.gl may initialize asynchronously so this can return a promise.
+     */
+    init(options: MapInitOptions): void | Promise<void>
+
+    /**
+     * Tear down the map and free all resources.
+     */
+    destroy(): void | Promise<void>
+
+    /**
+     * Get the underlying engine map object for escape hatch usage.
+     */
+    getNativeMap(): TNativeMap
+
+    /**
+     * Get the DOM container element holding the map.
+     */
+    getContainer(): HTMLElement
+
+    /**
+     * Jump to a center and zoom without animation.
+     */
+    setView(center: LatLngLike, zoom?: number, options?: ViewOptions): void
+
+    /**
+     * Set zoom without changing center.
+     */
+    setZoom(zoom: number, options?: ViewOptions): void
+
+    /**
+     * Set center without changing zoom.
+     */
+    setCenter(center: LatLngLike, options?: ViewOptions): void
+
+    /**
+     * Get the current zoom level.
+     */
+    getZoom(): number
+
+    /**
+     * Get the configured minimum zoom.
+     */
+    getMinZoom(): number
+
+    /**
+     * Get the configured maximum zoom.
+     */
+    getMaxZoom(): number
+
+    /**
+     * Get the current map center as an object with named fields.
+     */
+    getCenter(): LatLng
+
+    /**
+     * Get the visible geographic bounds.
+     */
+    getBounds(): BoundsLike
+
+    /**
+     * Get the full camera state including bearing and pitch.
+     */
+    getViewState(): ViewState
+
+    /**
+     * Set the full camera state. Leaflet adapter ignores bearing and pitch.
+     */
+    setViewState(state: ViewState, options?: ViewOptions): void
+
+    /**
+     * Set or clear maximum bounds. Pass null to remove the constraint.
+     */
+    setMaxBounds(bounds: BoundsLike | null): void
+
+    /**
+     * Adjust the view so the given bounds fit in the viewport.
+     * All engines support this natively. deck.gl adapters use
+     * WebMercatorViewport.fitBounds internally.
+     */
+    fitBounds(bounds: BoundsLike, options?: FitBoundsOptions): void
+
+    /**
+     * Smoothly animate to a destination.
+     * Leaflet adapter ignores bearing/pitch.
+     */
+    flyTo(options: FlyToOptions): void
+
+    /**
+     * Pan to a new center with animation.
+     */
+    panTo(center: LatLngLike, options?: ViewOptions): void
+
+    /**
+     * Tell the map its container changed size.
+     * Leaflet: invalidateSize(). deck.gl: handled automatically
+     * but adapters can force a redraw.
+     */
+    invalidateSize(): void
+
+    /**
+     * Get the pixel size of the map container as [width, height].
+     */
+    getSize(): PointLike
+
+    /**
+     * Get all layers currently on the map.
+     */
+    getLayers(): TLayer[]
+
+    /**
+     * Check if a layer is on the map by layer object or string id.
+     */
+    hasLayer(layer: TLayer | string): boolean
+
+    /**
+     * Add an already created native layer to the map.
+     */
+    addLayer(layer: TLayer): void
+
+    /**
+     * Create a layer from an options spec and add it to the map.
+     * deck.gl adapters append to the internal layers array.
+     */
+    createLayer(options: LayerOptions): TLayer
+
+    /**
+     * Remove a layer from the map by layer object or string id.
+     */
+    removeLayer(layer: TLayer | string): void
+
+    /**
+     * Update properties on an existing layer (opacity, style, etc).
+     */
+    updateLayer(layer: TLayer | string, options: Partial<LayerOptions>): TLayer
+
+    /**
+     * Set the z index of a layer to control draw order.
+     */
+    setLayerZIndex(layer: TLayer | string, zIndex: number): void
+
+    /**
+     * Move a layer to the top of the stack.
+     */
+    bringToFront(layer: TLayer | string): void
+
+    /**
+     * Move a layer to the bottom of the stack.
+     */
+    bringToBack(layer: TLayer | string): void
+
+    /**
+     * Set the opacity of a layer.
+     */
+    setLayerOpacity(layer: TLayer | string, opacity: number): void
+
+    /**
+     * Subscribe to a map event (click, moveend, zoomend, etc).
+     */
+    on(
+        eventName: string,
+        handler: MapEventHandler<TEvent>,
+        options?: MapEventOptions
+    ): void
+
+    /**
+     * Unsubscribe from a map event.
+     */
+    off(eventName: string, handler?: MapEventHandler<TEvent>): void
+
+    /**
+     * Fire a custom event on the map (e.g. newActiveFeature).
+     */
+    emit(eventName: string, data?: unknown): void
+
+    /**
+     * Register a handler called when the user clicks a feature.
+     * Leaflet: wired through onEachFeature click handlers.
+     * deck.gl: uses onClick picking callback.
+     */
+    onFeatureClick(handler: FeatureInteractionHandler): void
+
+    /**
+     * Register a handler called when the user hovers over a feature.
+     * Leaflet: mouseover/mouseout on vector layers.
+     * deck.gl: onHover picking callback.
+     */
+    onFeatureHover(handler: FeatureInteractionHandler): void
+
+    /**
+     * Query visible features at a point or within a box.
+     * Leaflet: iterate visible layers and test intersection.
+     * deck.gl: pickObject / pickObjects.
+     */
+    queryRenderedFeatures(
+        geometry: PointLike | [PointLike, PointLike],
+        options?: QueryFeaturesOptions
+    ): FeaturePickResult[]
+
+    /**
+     * Convert geographic coordinates to pixel coordinates.
+     */
+    projectCoordinates(latLng: LatLngLike, zoom?: number): PointLike
+
+    /**
+     * Convert pixel coordinates to geographic coordinates.
+     */
+    unprojectCoordinates(point: PointLike, zoom?: number): LatLngLike
+
+    /**
+     * Convert container pixel position to geographic coordinates.
+     */
+    containerPointToLatLng(point: PointLike): LatLngLike
+
+    /**
+     * Convert geographic coordinates to container pixel position.
+     */
+    latLngToContainerPoint(latLng: LatLngLike): PointLike
+}

--- a/src/essence/Basics/MapEngines/IMapEngineMarkers.ts
+++ b/src/essence/Basics/MapEngines/IMapEngineMarkers.ts
@@ -1,0 +1,33 @@
+import { MarkerOptions } from './types/layers'
+
+/**
+ * Optional marker support.
+ *
+ * Leaflet has native marker objects (L.Marker) so its adapter
+ * implements this interface.
+ *
+ * deck.gl has no marker concept. It uses IconLayer or ScatterplotLayer
+ * instead. The deck.gl adapter skips this interface and the calling
+ * code would use createLayer with an icon layer config.
+ *
+ * This is intentionally separate from IMapEngine so that code
+ * depending on markers can check for support at runtime:
+ *
+ *   if ('addMarker' in engine) { engine.addMarker(...) }
+ */
+export interface IMapEngineMarkers<TMarker = unknown> {
+    /**
+     * Add a marker to the map.
+     */
+    addMarker(options: MarkerOptions): TMarker
+
+    /**
+     * Remove a marker from the map by marker object or string id.
+     */
+    removeMarker(marker: TMarker | string): void
+
+    /**
+     * Update an existing marker's position, icon, or other properties.
+     */
+    updateMarker(marker: TMarker | string, options: Partial<MarkerOptions>): TMarker
+}

--- a/src/essence/Basics/MapEngines/index.ts
+++ b/src/essence/Basics/MapEngines/index.ts
@@ -1,0 +1,55 @@
+export type {
+    LatLng,
+    LatLngTuple,
+    LngLatTuple,
+    LatLngLike,
+    Point,
+    PointLike,
+    Bounds,
+    BoundsLike,
+    PaddingLike,
+} from './types/geometry'
+
+export type {
+    ViewState,
+    ViewOptions,
+    FlyToOptions,
+    FitBoundsOptions,
+    MapInitOptions,
+    ProjectionOptions,
+} from './types/view'
+
+export type {
+    LayerOptions,
+    TileLayerOptions,
+    GeoJSONLayerOptions,
+    ImageOverlayOptions,
+    VectorTileLayerOptions,
+    PointCloudLayerOptions,
+    MarkerOptions,
+    IconOptions,
+} from './types/layers'
+
+export type {
+    MapEventHandler,
+    MapEventOptions,
+    FeaturePickResult,
+    FeatureInteractionHandler,
+    QueryFeaturesOptions,
+} from './types/events'
+
+export type {
+    MapEngineType,
+    RenderableLayerType,
+    StructuralLayerType,
+    LayerType,
+    ToolEngineSupport,
+} from './types/engine'
+
+export {
+    ENGINE_LAYER_SUPPORT,
+    engineSupportsLayer,
+} from './types/engine'
+
+export type { IMapEngine } from './IMapEngine'
+export type { IMapEngineMarkers } from './IMapEngineMarkers'

--- a/src/essence/Basics/MapEngines/types/engine.ts
+++ b/src/essence/Basics/MapEngines/types/engine.ts
@@ -1,0 +1,71 @@
+/**
+ * Map engine identifiers. Each mission is configured with one engine
+ * and that engine cannot be changed after mission creation.
+ */
+export type MapEngineType = 'leaflet' | 'deckgl'
+
+/**
+ * Renderable layer types that an engine can actually draw.
+ * Not every engine supports every type.
+ */
+export type RenderableLayerType =
+    | 'vector'
+    | 'tile'
+    | 'vectortile'
+    | 'data'
+    | 'image'
+    | 'model'
+    | 'video'
+    | 'velocity'
+    | 'pointcloud'
+
+/**
+ * Structural layer types used by MMGIS for UI and data fetching.
+ * These are not rendered by any engine directly.
+ *   query:  fetches data on demand, rendered as vector once loaded
+ *   header: grouping label in the layer tree, never rendered
+ */
+export type StructuralLayerType = 'query' | 'header'
+
+/**
+ * All MMGIS layer types. Union of renderable and structural.
+ */
+export type LayerType = RenderableLayerType | StructuralLayerType
+
+/**
+ * Which renderable layer types each engine supports.
+ *
+ * Leaflet:
+ *   vector, tile, vectortile (via L.VectorGrid plugin),
+ *   data (via L.TileLayer.GL), image (via georaster plugin),
+ *   video (L.VideoOverlay), velocity (leaflet-velocity plugin)
+ *
+ * deck.gl:
+ *   vector (GeoJsonLayer), tile (TileLayer/BitmapLayer),
+ *   pointcloud (PointCloudLayer, high density point data)
+ *   Basemap rendering (Mapbox/MapLibre) is an internal detail
+ *   of the deck.gl adapter and not exposed as a separate engine.
+ */
+export const ENGINE_LAYER_SUPPORT: Record<MapEngineType, RenderableLayerType[]> = {
+    leaflet: ['vector', 'tile', 'vectortile', 'data', 'image', 'video', 'velocity'],
+    deckgl: ['vector', 'tile', 'pointcloud'],
+}
+
+/**
+ * Check if a given engine supports a renderable layer type.
+ */
+export function engineSupportsLayer(
+    engine: MapEngineType,
+    layerType: RenderableLayerType
+): boolean {
+    return ENGINE_LAYER_SUPPORT[engine].includes(layerType)
+}
+
+/**
+ * Metadata a tool declares so the configuration UI can show
+ * or hide tools based on the mission's selected engine.
+ */
+export interface ToolEngineSupport {
+    toolName: string
+    supportedEngines: MapEngineType[]
+}

--- a/src/essence/Basics/MapEngines/types/events.ts
+++ b/src/essence/Basics/MapEngines/types/events.ts
@@ -1,0 +1,41 @@
+import { LatLngLike, PointLike } from './geometry'
+
+/**
+ * Handler signature for map events.
+ */
+export type MapEventHandler<TEvent = unknown> = (event: TEvent) => void
+
+/**
+ * Options when subscribing to a map event.
+ */
+export interface MapEventOptions {
+    once?: boolean
+}
+
+/**
+ * Result of a feature pick from click, hover, or spatial query.
+ * Each engine fills this from its own picking system:
+ *   Leaflet uses DOM event propagation on vector layers
+ *   deck.gl uses GPU based picking (pickObject / pickMultipleObjects)
+ */
+export interface FeaturePickResult {
+    feature: Record<string, unknown> | null
+    layerId?: string
+    latlng?: LatLngLike
+    pixel?: PointLike
+}
+
+/**
+ * Callback for feature level interactions (click, hover, spatial query).
+ */
+export type FeatureInteractionHandler = (result: FeaturePickResult) => void
+
+/**
+ * Options for spatial feature queries.
+ * Leaflet and deck.gl adapters implement this using their
+ * own picking mechanisms.
+ */
+export interface QueryFeaturesOptions {
+    layers?: string[]
+    filter?: unknown[]
+}

--- a/src/essence/Basics/MapEngines/types/geometry.ts
+++ b/src/essence/Basics/MapEngines/types/geometry.ts
@@ -1,0 +1,68 @@
+/**
+ * Geographic coordinate as a named object.
+ * Named fields avoid the lat/lng vs lng/lat ordering confusion
+ * that exists between Leaflet ([lat, lng]) and deck.gl ([lng, lat]).
+ * Adapters convert to the engine's native order internally.
+ */
+export interface LatLng {
+    lat: number
+    lng: number
+    alt?: number
+}
+
+/**
+ * Tuple in Leaflet order: [lat, lng] or [lat, lng, alt].
+ * Only use this when interfacing with Leaflet APIs or existing
+ * MMGIS config that already stores coordinates this way.
+ */
+export type LatLngTuple = [number, number] | [number, number, number]
+
+/**
+ * Tuple in GeoJSON/deck.gl order: [lng, lat] or [lng, lat, alt].
+ * This is the GeoJSON standard and what deck.gl expects.
+ */
+export type LngLatTuple = [number, number] | [number, number, number]
+
+/**
+ * Accepts the named object, a Leaflet ordered tuple, or a GeoJSON ordered tuple.
+ * When using tuples the adapter must know which order to expect.
+ * Prefer the object form to avoid ambiguity.
+ */
+export type LatLngLike = LatLng | LatLngTuple
+
+/**
+ * A 2D point for pixel or projected coordinates.
+ */
+export interface Point {
+    x: number
+    y: number
+}
+
+/**
+ * Accepts either object or tuple form of a 2D point.
+ */
+export type PointLike = Point | [number, number]
+
+/**
+ * Geographic bounds as southwest and northeast corners.
+ */
+export interface Bounds {
+    southWest: LatLngLike
+    northEast: LatLngLike
+}
+
+/**
+ * Accepts either object or tuple form of bounds.
+ */
+export type BoundsLike = Bounds | [LatLngLike, LatLngLike]
+
+/**
+ * Padding for fitBounds and similar operations.
+ * Single number applies equally to all sides.
+ * Object form specifies each side independently.
+ * Tuple is [top, right, bottom, left].
+ */
+export type PaddingLike =
+    | number
+    | { top: number; right: number; bottom: number; left: number }
+    | [number, number, number, number]

--- a/src/essence/Basics/MapEngines/types/layers.ts
+++ b/src/essence/Basics/MapEngines/types/layers.ts
@@ -1,0 +1,139 @@
+import { LatLngLike, BoundsLike } from './geometry'
+import { LayerType } from './engine'
+
+/**
+ * Base layer options shared across all layer types.
+ */
+export interface LayerOptions {
+    id?: string
+    type?: LayerType
+    url?: string
+    bounds?: BoundsLike
+    opacity?: number
+    zIndex?: number
+    minZoom?: number
+    maxZoom?: number
+    interactive?: boolean
+    visible?: boolean
+    style?: Record<string, unknown>
+    metadata?: Record<string, unknown>
+}
+
+/**
+ * Options for tile layers (raster XYZ or TMS).
+ *
+ * Leaflet: creates L.TileLayer with url template and tms flag.
+ * deck.gl: creates a TileLayer with renderSubLayers returning
+ *   BitmapLayer for raster tiles. The url template uses {x},{y},{z}
+ *   placeholders just like Leaflet.
+ *
+ * deck.gl specific props (tileSize, maxCacheSize, refinementStrategy,
+ * maxRequests, debounceTime, onTileLoad, onTileError) are passed
+ * through via the nativeOptions escape hatch so that the adapter
+ * can forward them directly to deck.gl's TileLayer constructor.
+ */
+export interface TileLayerOptions extends LayerOptions {
+    tms?: boolean
+    subdomains?: string | string[]
+    attribution?: string
+    time?: string
+    maxNativeZoom?: number
+    tileSize?: number
+    nativeOptions?: Record<string, unknown>
+}
+
+/**
+ * Options for GeoJSON vector layers.
+ *
+ * Leaflet: creates L.GeoJSON using the callback props directly.
+ * deck.gl: creates a GeoJsonLayer. The adapter maps style properties
+ *   to deck.gl accessors (fillColor = getFillColor, strokeColor = getLineColor,
+ *   strokeWidth = getLineWidth, radius = getRadius, elevation = getElevation).
+ *
+ * deck.gl GeoJsonLayer specific props like pointType, lineWidthUnits,
+ * lineJointRounded, elevationScale, extruded, material etc. are passed
+ * through via the nativeOptions escape hatch.
+ */
+export interface GeoJSONLayerOptions<TLayer = unknown> extends Omit<LayerOptions, 'style'> {
+    geojson: Record<string, unknown>
+    style?: Record<string, unknown> | ((feature: Record<string, unknown>) => Record<string, unknown>)
+    onEachFeature?: (feature: Record<string, unknown>, layer: TLayer) => void
+    pointToLayer?: (feature: Record<string, unknown>, latlng: LatLngLike) => TLayer
+    filter?: (feature: Record<string, unknown>) => boolean
+    filled?: boolean
+    stroked?: boolean
+    extruded?: boolean
+    pointType?: string
+    lineWidthUnits?: 'pixels' | 'meters' | 'common'
+    nativeOptions?: Record<string, unknown>
+}
+
+/**
+ * Options for image overlay layers (GeoTIFF, raster overlays).
+ */
+export interface ImageOverlayOptions extends LayerOptions {
+    bounds: BoundsLike
+    colorScale?: string
+    clampLow?: boolean
+    clampHigh?: boolean
+}
+
+/**
+ * Options for vector tile (MVT/protobuf) layers.
+ */
+export interface VectorTileLayerOptions extends LayerOptions {
+    vectorTileLayerStyles?: Record<string, unknown>
+    maxNativeZoom?: number
+    attribution?: string
+}
+
+/**
+ * Options for point cloud layers.
+ * deck.gl renders these via PointCloudLayer for high density datasets.
+ * Currently only supported by the deck.gl engine.
+ *
+ * The adapter forwards pointSize, sizeUnits, and material directly
+ * to deck.gl's PointCloudLayer. Data accessors (getPosition, getNormal,
+ * getColor) are wired by the
+ * adapter based on the data shape or can be overridden via nativeOptions.
+ *
+ * For LAS/LAZ files pass the url as data and provide the LASLoader
+ * in the loaders array. The adapter will forward loaders to deck.gl.
+ */
+export interface PointCloudLayerOptions extends LayerOptions {
+    data?: string | Record<string, unknown>
+    pointSize?: number
+    sizeUnits?: 'pixels' | 'meters' | 'common'
+    material?: Record<string, unknown>
+    coordinateSystem?: string
+    coordinateOrigin?: [number, number] | [number, number, number]
+    loaders?: unknown[]
+    nativeOptions?: Record<string, unknown>
+}
+
+/**
+ * Marker options for creating or updating markers.
+ */
+export interface MarkerOptions {
+    id?: string
+    position: LatLngLike
+    icon?: IconOptions
+    draggable?: boolean
+    interactive?: boolean
+    zIndexOffset?: number
+    rotation?: number
+    metadata?: Record<string, unknown>
+}
+
+/**
+ * Icon configuration for markers.
+ */
+export interface IconOptions {
+    url?: string
+    size?: [number, number]
+    anchor?: [number, number]
+    className?: string
+    color?: string
+    scale?: number
+    element?: HTMLElement
+}

--- a/src/essence/Basics/MapEngines/types/view.ts
+++ b/src/essence/Basics/MapEngines/types/view.ts
@@ -1,0 +1,81 @@
+import { LatLngLike, BoundsLike, PaddingLike, PointLike } from './geometry'
+
+/**
+ * Full camera state. Leaflet adapter ignores bearing and pitch.
+ * deck.gl uses all fields.
+ */
+export interface ViewState {
+    center: LatLngLike
+    zoom: number
+    bearing?: number
+    pitch?: number
+}
+
+/**
+ * Options for animated view transitions.
+ */
+export interface ViewOptions {
+    animate?: boolean
+    duration?: number
+    easeLinearity?: number
+}
+
+/**
+ * Options for flyTo where center, zoom, bearing, pitch are all
+ * part of a single object. Leaflet adapter ignores bearing and pitch.
+ */
+export interface FlyToOptions extends ViewOptions {
+    center: LatLngLike
+    zoom?: number
+    bearing?: number
+    pitch?: number
+    speed?: number
+    curve?: number
+    padding?: PaddingLike
+    offset?: PointLike
+}
+
+/**
+ * Options for fitting bounds into the viewport.
+ */
+export interface FitBoundsOptions extends ViewOptions {
+    padding?: PaddingLike
+    maxZoom?: number
+    offset?: PointLike
+}
+
+/**
+ * Options passed when initializing a map engine.
+ */
+export interface MapInitOptions {
+    containerId: string
+    center?: LatLngLike
+    zoom?: number
+    minZoom?: number
+    maxZoom?: number
+    maxBounds?: BoundsLike | null
+    bearing?: number
+    pitch?: number
+    zoomControl?: boolean
+    keyboard?: boolean
+    fadeAnimation?: boolean
+    worldCopyJump?: boolean
+    zoomDelta?: number
+    zoomSnap?: number
+    wheelPxPerZoomLevel?: number
+    editable?: boolean
+    projection?: ProjectionOptions
+}
+
+/**
+ * Projection and CRS options. Used primarily by Leaflet for custom
+ * planetary projections.
+ */
+export interface ProjectionOptions {
+    epsg?: string
+    proj4?: string
+    origin?: PointLike
+    bounds?: BoundsLike
+    resolutions?: number[]
+    radius?: number
+}


### PR DESCRIPTION
## Purpose

Define an `IMapEngine` TypeScript interface that acts as the common contract for all map engine adapters (for now only Leaflet and deck.gl). It includes the supporting types for geometry, view state, layers and events.

Note: To keep the scope a bit tight, I did not include Mapbox as a dedicated engine the interface. If I understood correctly, for this phase, Mapbox will only be used as a basemap provider inside the deck.gl adapter (which is an internal detail) while deck.gl remains the primary visualization engine.

Markers are defined in a separate optional `IMapEngineMarkers` interface, because deck.gl does not have a built-in marker concept.

For deck.gl layers, I currently defined `TileLayerOptions`, `GeoJSONLayerOptions` and `PointCloudLayerOptions`. For each, I included a `nativeOptions` field as an "escape hatch" for engine-specific props (eg. `refinementStrategy`, `material`, `loaders`) without complicating the shared interface. We can add more as we develop the adapter.

## Issues

Closes https://github.com/NASA-IMPACT/MMGIS/issues/14

## Testing

Types only, no runtime code. Verified the interface covers all methods listed in the acceptance criteria. Cross-referenced deck.gl layer prop names against official docs for TileLayer, GeoJsonLayer, PointCloudLayer and IconLayer.