### PR TITLE
feat: map engine registry

### DIFF
--- a/src/essence/Basics/MapEngines/MapEngineRegistry.ts
+++ b/src/essence/Basics/MapEngines/MapEngineRegistry.ts
@@ -1,0 +1,86 @@
+import type { IMapEngine } from './IMapEngine'
+import type { MapInitOptions } from './types/view'
+import type { MapEngineAdapterClass } from './types/engine'
+
+/**
+ * Registry for map engine adapters. Tracks available engine types,
+ * instantiates their adapters, and manages their lifecycle.
+ */
+class MapEngineRegistry {
+    private adapters = new Map<string, MapEngineAdapterClass>()
+    private activeEngine: IMapEngine | null = null
+    private engines = new Map<string, IMapEngine>()
+
+    /**
+     * Register a new engine adapter class under the given name.
+     * @throws {Error} If name is not a non-empty string or adapterClass is not a constructor.
+     */
+    register(name: string, adapterClass: MapEngineAdapterClass): void {
+        if (typeof name !== 'string' || name.length === 0) {
+            throw new Error('Engine name must be a non-empty string')
+        }
+        if (typeof adapterClass !== 'function') {
+            throw new Error('Adapter class must be a constructor')
+        }
+        this.adapters.set(name, adapterClass)
+    }
+
+    /**
+     * Instantiate an adapter for a registered engine name.
+     * @throws {Error} If no adapter is registered under the given name.
+     */
+    createEngine(name: string, options?: MapInitOptions): IMapEngine {
+        const AdapterClass = this.adapters.get(name)
+        if (!AdapterClass) {
+            throw new Error(`No adapter registered for engine "${name}"`)
+        }
+        const engine = new AdapterClass(options)
+        this.engines.set(name, engine)
+        return engine
+    }
+
+    initializeEngine(engine: IMapEngine, options: MapInitOptions): void | Promise<void> {
+        return engine.init(options)
+    }
+
+    /**
+     * Destroy a map engine and remove it from tracked engines.
+     * Clears the active engine reference if the destroyed engine was active.
+     */
+    destroyEngine(engine: IMapEngine): void | Promise<void> {
+        for (const [name, tracked] of this.engines) {
+            if (tracked === engine) {
+                this.engines.delete(name)
+                break
+            }
+        }
+        if (this.activeEngine === engine) {
+            this.activeEngine = null
+        }
+        return engine.destroy()
+    }
+
+    getActiveEngine(): IMapEngine | null {
+        return this.activeEngine
+    }
+
+    setActiveEngine(engine: IMapEngine): void {
+        this.activeEngine = engine
+    }
+
+    hasEngine(name: string): boolean {
+        return this.adapters.has(name)
+    }
+
+    getRegisteredEngines(): string[] {
+        return Array.from(this.adapters.keys())
+    }
+
+    getEngine(name: string): IMapEngine | undefined {
+        return this.engines.get(name)
+    }
+}
+
+export default MapEngineRegistry
+
+export const mapEngineRegistry = new MapEngineRegistry()

--- a/src/essence/Basics/MapEngines/MapEngineRegistry.ts
+++ b/src/essence/Basics/MapEngines/MapEngineRegistry.ts
@@ -1,21 +1,21 @@
 import type { IMapEngine } from './IMapEngine'
 import type { MapInitOptions } from './types/view'
-import type { MapEngineAdapterClass } from './types/engine'
+import type { MapEngineAdapterClass, MapEngineType } from './types/engine'
 
 /**
  * Registry for map engine adapters. Tracks available engine types,
  * instantiates their adapters, and manages their lifecycle.
  */
 class MapEngineRegistry {
-    private adapters = new Map<string, MapEngineAdapterClass>()
+    private adapters = new Map<MapEngineType, MapEngineAdapterClass>()
     private activeEngine: IMapEngine | null = null
-    private engines = new Map<string, IMapEngine>()
+    private engines = new Map<MapEngineType, IMapEngine>()
 
     /**
      * Register a new engine adapter class under the given name.
      * @throws {Error} If name is not a non-empty string or adapterClass is not a constructor.
      */
-    register(name: string, adapterClass: MapEngineAdapterClass): void {
+    register(name: MapEngineType, adapterClass: MapEngineAdapterClass): void {
         if (typeof name !== 'string' || name.length === 0) {
             throw new Error('Engine name must be a non-empty string')
         }
@@ -29,7 +29,7 @@ class MapEngineRegistry {
      * Instantiate an adapter for a registered engine name.
      * @throws {Error} If no adapter is registered under the given name.
      */
-    createEngine(name: string, options?: MapInitOptions): IMapEngine {
+    createEngine(name: MapEngineType, options?: MapInitOptions): IMapEngine {
         const AdapterClass = this.adapters.get(name)
         if (!AdapterClass) {
             throw new Error(`No adapter registered for engine "${name}"`)
@@ -68,15 +68,15 @@ class MapEngineRegistry {
         this.activeEngine = engine
     }
 
-    hasEngine(name: string): boolean {
+    hasEngine(name: MapEngineType): boolean {
         return this.adapters.has(name)
     }
 
-    getRegisteredEngines(): string[] {
+    getRegisteredEngines(): MapEngineType[] {
         return Array.from(this.adapters.keys())
     }
 
-    getEngine(name: string): IMapEngine | undefined {
+    getEngine(name: MapEngineType): IMapEngine | undefined {
         return this.engines.get(name)
     }
 }

--- a/src/essence/Basics/MapEngines/index.ts
+++ b/src/essence/Basics/MapEngines/index.ts
@@ -40,6 +40,7 @@ export type {
 
 export type {
     MapEngineType,
+    MapEngineAdapterClass,
     RenderableLayerType,
     StructuralLayerType,
     LayerType,
@@ -53,3 +54,5 @@ export {
 
 export type { IMapEngine } from './IMapEngine'
 export type { IMapEngineMarkers } from './IMapEngineMarkers'
+
+export { default as MapEngineRegistry, mapEngineRegistry } from './MapEngineRegistry'

--- a/src/essence/Basics/MapEngines/index.ts
+++ b/src/essence/Basics/MapEngines/index.ts
@@ -48,6 +48,7 @@ export type {
 } from './types/engine'
 
 export {
+    MAP_ENGINE,
     ENGINE_LAYER_SUPPORT,
     engineSupportsLayer,
 } from './types/engine'

--- a/src/essence/Basics/MapEngines/types/engine.ts
+++ b/src/essence/Basics/MapEngines/types/engine.ts
@@ -4,7 +4,12 @@ import type { IMapEngine } from '../IMapEngine'
  * Map engine identifiers. Each mission is configured with one engine
  * and that engine cannot be changed after mission creation.
  */
-export type MapEngineType = 'leaflet' | 'deckgl'
+export const MAP_ENGINE = {
+    LEAFLET: 'leaflet',
+    DECKGL: 'deckgl',
+} as const
+
+export type MapEngineType = (typeof MAP_ENGINE)[keyof typeof MAP_ENGINE]
 
 /**
  * Renderable layer types that an engine can actually draw.
@@ -49,8 +54,8 @@ export type LayerType = RenderableLayerType | StructuralLayerType
  *   of the deck.gl adapter and not exposed as a separate engine.
  */
 export const ENGINE_LAYER_SUPPORT: Record<MapEngineType, RenderableLayerType[]> = {
-    leaflet: ['vector', 'tile', 'vectortile', 'data', 'image', 'video', 'velocity'],
-    deckgl: ['vector', 'tile', 'pointcloud'],
+    [MAP_ENGINE.LEAFLET]: ['vector', 'tile', 'vectortile', 'data', 'image', 'video', 'velocity'],
+    [MAP_ENGINE.DECKGL]: ['vector', 'tile', 'pointcloud'],
 }
 
 /**

--- a/src/essence/Basics/MapEngines/types/engine.ts
+++ b/src/essence/Basics/MapEngines/types/engine.ts
@@ -1,3 +1,5 @@
+import type { IMapEngine } from '../IMapEngine'
+
 /**
  * Map engine identifiers. Each mission is configured with one engine
  * and that engine cannot be changed after mission creation.
@@ -60,6 +62,12 @@ export function engineSupportsLayer(
 ): boolean {
     return ENGINE_LAYER_SUPPORT[engine].includes(layerType)
 }
+
+/**
+ * Constructor signature for a class that implements IMapEngine.
+ * Used by the MapEngineRegistry to instantiate adapters.
+ */
+export type MapEngineAdapterClass = new (...args: unknown[]) => IMapEngine
 
 /**
  * Metadata a tool declares so the configuration UI can show

--- a/tests/unit/mapEngineRegistry.spec.js
+++ b/tests/unit/mapEngineRegistry.spec.js
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test'
 import MapEngineRegistry from '../../src/essence/Basics/MapEngines/MapEngineRegistry.ts'
+import { MAP_ENGINE } from '../../src/essence/Basics/MapEngines/index.ts'
 
-function createMockAdapterClass(engineType = 'leaflet') {
+function createMockAdapterClass(engineType = MAP_ENGINE.LEAFLET) {
     return class MockAdapter {
         engineType = engineType
         initialized = false
@@ -22,7 +23,7 @@ function createMockAdapterClass(engineType = 'leaflet') {
     }
 }
 
-function createAsyncMockAdapterClass(engineType = 'deckgl') {
+function createAsyncMockAdapterClass(engineType = MAP_ENGINE.DECKGL) {
     return class AsyncMockAdapter {
         engineType = engineType
         initialized = false
@@ -53,19 +54,19 @@ test.describe('MapEngineRegistry', () => {
     test.describe('register', () => {
         test('registers an adapter class under a name', () => {
             const MockAdapter = createMockAdapterClass()
-            registry.register('leaflet', MockAdapter)
+            registry.register(MAP_ENGINE.LEAFLET, MockAdapter)
 
-            expect(registry.hasEngine('leaflet')).toBe(true)
+            expect(registry.hasEngine(MAP_ENGINE.LEAFLET)).toBe(true)
         })
 
         test('overwrites a previously registered adapter', () => {
-            const First = createMockAdapterClass('leaflet')
-            const Second = createMockAdapterClass('leaflet')
+            const First = createMockAdapterClass(MAP_ENGINE.LEAFLET)
+            const Second = createMockAdapterClass(MAP_ENGINE.LEAFLET)
 
-            registry.register('leaflet', First)
-            registry.register('leaflet', Second)
+            registry.register(MAP_ENGINE.LEAFLET, First)
+            registry.register(MAP_ENGINE.LEAFLET, Second)
 
-            const engine = registry.createEngine('leaflet')
+            const engine = registry.createEngine(MAP_ENGINE.LEAFLET)
             expect(engine).toBeInstanceOf(Second)
         })
 
@@ -82,7 +83,7 @@ test.describe('MapEngineRegistry', () => {
         })
 
         test('throws when adapterClass is not a constructor', () => {
-            expect(() => registry.register('leaflet', {})).toThrow(
+            expect(() => registry.register(MAP_ENGINE.LEAFLET, {})).toThrow(
                 'Adapter class must be a constructor'
             )
         })
@@ -91,18 +92,18 @@ test.describe('MapEngineRegistry', () => {
     test.describe('createEngine', () => {
         test('creates an instance of the registered adapter', () => {
             const MockAdapter = createMockAdapterClass()
-            registry.register('leaflet', MockAdapter)
+            registry.register(MAP_ENGINE.LEAFLET, MockAdapter)
 
-            const engine = registry.createEngine('leaflet')
+            const engine = registry.createEngine(MAP_ENGINE.LEAFLET)
             expect(engine).toBeInstanceOf(MockAdapter)
-            expect(engine.engineType).toBe('leaflet')
+            expect(engine.engineType).toBe(MAP_ENGINE.LEAFLET)
         })
 
         test('tracks created engine for later retrieval', () => {
-            registry.register('leaflet', createMockAdapterClass())
-            const engine = registry.createEngine('leaflet')
+            registry.register(MAP_ENGINE.LEAFLET, createMockAdapterClass())
+            const engine = registry.createEngine(MAP_ENGINE.LEAFLET)
 
-            expect(registry.getEngine('leaflet')).toBe(engine)
+            expect(registry.getEngine(MAP_ENGINE.LEAFLET)).toBe(engine)
         })
 
         test('throws for unregistered engine name', () => {
@@ -114,8 +115,8 @@ test.describe('MapEngineRegistry', () => {
 
     test.describe('initializeEngine', () => {
         test('calls init on the engine with options', () => {
-            registry.register('leaflet', createMockAdapterClass())
-            const engine = registry.createEngine('leaflet')
+            registry.register(MAP_ENGINE.LEAFLET, createMockAdapterClass())
+            const engine = registry.createEngine(MAP_ENGINE.LEAFLET)
             const options = { containerId: 'map' }
 
             registry.initializeEngine(engine, options)
@@ -125,8 +126,8 @@ test.describe('MapEngineRegistry', () => {
         })
 
         test('supports async init', async () => {
-            registry.register('deckgl', createAsyncMockAdapterClass())
-            const engine = registry.createEngine('deckgl')
+            registry.register(MAP_ENGINE.DECKGL, createAsyncMockAdapterClass())
+            const engine = registry.createEngine(MAP_ENGINE.DECKGL)
             const options = { containerId: 'map' }
 
             await registry.initializeEngine(engine, options)
@@ -137,8 +138,8 @@ test.describe('MapEngineRegistry', () => {
 
     test.describe('destroyEngine', () => {
         test('calls destroy on the engine', () => {
-            registry.register('leaflet', createMockAdapterClass())
-            const engine = registry.createEngine('leaflet')
+            registry.register(MAP_ENGINE.LEAFLET, createMockAdapterClass())
+            const engine = registry.createEngine(MAP_ENGINE.LEAFLET)
 
             registry.destroyEngine(engine)
 
@@ -146,17 +147,17 @@ test.describe('MapEngineRegistry', () => {
         })
 
         test('removes the engine from tracked engines', () => {
-            registry.register('leaflet', createMockAdapterClass())
-            const engine = registry.createEngine('leaflet')
+            registry.register(MAP_ENGINE.LEAFLET, createMockAdapterClass())
+            const engine = registry.createEngine(MAP_ENGINE.LEAFLET)
 
             registry.destroyEngine(engine)
 
-            expect(registry.getEngine('leaflet')).toBeUndefined()
+            expect(registry.getEngine(MAP_ENGINE.LEAFLET)).toBeUndefined()
         })
 
         test('clears activeEngine if the destroyed engine was active', () => {
-            registry.register('leaflet', createMockAdapterClass())
-            const engine = registry.createEngine('leaflet')
+            registry.register(MAP_ENGINE.LEAFLET, createMockAdapterClass())
+            const engine = registry.createEngine(MAP_ENGINE.LEAFLET)
             registry.setActiveEngine(engine)
 
             registry.destroyEngine(engine)
@@ -165,8 +166,8 @@ test.describe('MapEngineRegistry', () => {
         })
 
         test('supports async destroy', async () => {
-            registry.register('deckgl', createAsyncMockAdapterClass())
-            const engine = registry.createEngine('deckgl')
+            registry.register(MAP_ENGINE.DECKGL, createAsyncMockAdapterClass())
+            const engine = registry.createEngine(MAP_ENGINE.DECKGL)
 
             await registry.destroyEngine(engine)
 
@@ -180,8 +181,8 @@ test.describe('MapEngineRegistry', () => {
         })
 
         test('setActiveEngine stores the engine', () => {
-            registry.register('leaflet', createMockAdapterClass())
-            const engine = registry.createEngine('leaflet')
+            registry.register(MAP_ENGINE.LEAFLET, createMockAdapterClass())
+            const engine = registry.createEngine(MAP_ENGINE.LEAFLET)
 
             registry.setActiveEngine(engine)
 
@@ -191,12 +192,12 @@ test.describe('MapEngineRegistry', () => {
 
     test.describe('hasEngine', () => {
         test('returns false for unregistered name', () => {
-            expect(registry.hasEngine('leaflet')).toBe(false)
+            expect(registry.hasEngine(MAP_ENGINE.LEAFLET)).toBe(false)
         })
 
         test('returns true for registered name', () => {
-            registry.register('leaflet', createMockAdapterClass())
-            expect(registry.hasEngine('leaflet')).toBe(true)
+            registry.register(MAP_ENGINE.LEAFLET, createMockAdapterClass())
+            expect(registry.hasEngine(MAP_ENGINE.LEAFLET)).toBe(true)
         })
     })
 
@@ -206,26 +207,26 @@ test.describe('MapEngineRegistry', () => {
         })
 
         test('returns all registered engine names', () => {
-            registry.register('leaflet', createMockAdapterClass())
-            registry.register('deckgl', createAsyncMockAdapterClass())
+            registry.register(MAP_ENGINE.LEAFLET, createMockAdapterClass())
+            registry.register(MAP_ENGINE.DECKGL, createAsyncMockAdapterClass())
 
             const names = registry.getRegisteredEngines()
-            expect(names).toContain('leaflet')
-            expect(names).toContain('deckgl')
+            expect(names).toContain(MAP_ENGINE.LEAFLET)
+            expect(names).toContain(MAP_ENGINE.DECKGL)
             expect(names.length).toBe(2)
         })
     })
 
     test.describe('getEngine', () => {
         test('returns undefined for uncreated engine', () => {
-            expect(registry.getEngine('leaflet')).toBeUndefined()
+            expect(registry.getEngine(MAP_ENGINE.LEAFLET)).toBeUndefined()
         })
 
         test('returns the created engine instance', () => {
-            registry.register('leaflet', createMockAdapterClass())
-            const engine = registry.createEngine('leaflet')
+            registry.register(MAP_ENGINE.LEAFLET, createMockAdapterClass())
+            const engine = registry.createEngine(MAP_ENGINE.LEAFLET)
 
-            expect(registry.getEngine('leaflet')).toBe(engine)
+            expect(registry.getEngine(MAP_ENGINE.LEAFLET)).toBe(engine)
         })
     })
 })

--- a/tests/unit/mapEngineRegistry.spec.js
+++ b/tests/unit/mapEngineRegistry.spec.js
@@ -1,0 +1,231 @@
+import { test, expect } from '@playwright/test'
+import MapEngineRegistry from '../../src/essence/Basics/MapEngines/MapEngineRegistry.ts'
+
+function createMockAdapterClass(engineType = 'leaflet') {
+    return class MockAdapter {
+        engineType = engineType
+        initialized = false
+        destroyed = false
+
+        init(options) {
+            this.initialized = true
+            this.initOptions = options
+        }
+
+        destroy() {
+            this.destroyed = true
+        }
+
+        getNativeMap() {
+            return null
+        }
+    }
+}
+
+function createAsyncMockAdapterClass(engineType = 'deckgl') {
+    return class AsyncMockAdapter {
+        engineType = engineType
+        initialized = false
+        destroyed = false
+
+        async init(options) {
+            this.initialized = true
+            this.initOptions = options
+        }
+
+        async destroy() {
+            this.destroyed = true
+        }
+
+        getNativeMap() {
+            return null
+        }
+    }
+}
+
+test.describe('MapEngineRegistry', () => {
+    let registry
+
+    test.beforeEach(() => {
+        registry = new MapEngineRegistry()
+    })
+
+    test.describe('register', () => {
+        test('registers an adapter class under a name', () => {
+            const MockAdapter = createMockAdapterClass()
+            registry.register('leaflet', MockAdapter)
+
+            expect(registry.hasEngine('leaflet')).toBe(true)
+        })
+
+        test('overwrites a previously registered adapter', () => {
+            const First = createMockAdapterClass('leaflet')
+            const Second = createMockAdapterClass('leaflet')
+
+            registry.register('leaflet', First)
+            registry.register('leaflet', Second)
+
+            const engine = registry.createEngine('leaflet')
+            expect(engine).toBeInstanceOf(Second)
+        })
+
+        test('throws when name is empty', () => {
+            expect(() => registry.register('', createMockAdapterClass())).toThrow(
+                'Engine name must be a non-empty string'
+            )
+        })
+
+        test('throws when name is not a string', () => {
+            expect(() => registry.register(42, createMockAdapterClass())).toThrow(
+                'Engine name must be a non-empty string'
+            )
+        })
+
+        test('throws when adapterClass is not a constructor', () => {
+            expect(() => registry.register('leaflet', {})).toThrow(
+                'Adapter class must be a constructor'
+            )
+        })
+    })
+
+    test.describe('createEngine', () => {
+        test('creates an instance of the registered adapter', () => {
+            const MockAdapter = createMockAdapterClass()
+            registry.register('leaflet', MockAdapter)
+
+            const engine = registry.createEngine('leaflet')
+            expect(engine).toBeInstanceOf(MockAdapter)
+            expect(engine.engineType).toBe('leaflet')
+        })
+
+        test('tracks created engine for later retrieval', () => {
+            registry.register('leaflet', createMockAdapterClass())
+            const engine = registry.createEngine('leaflet')
+
+            expect(registry.getEngine('leaflet')).toBe(engine)
+        })
+
+        test('throws for unregistered engine name', () => {
+            expect(() => registry.createEngine('unknown')).toThrow(
+                'No adapter registered for engine "unknown"'
+            )
+        })
+    })
+
+    test.describe('initializeEngine', () => {
+        test('calls init on the engine with options', () => {
+            registry.register('leaflet', createMockAdapterClass())
+            const engine = registry.createEngine('leaflet')
+            const options = { containerId: 'map' }
+
+            registry.initializeEngine(engine, options)
+
+            expect(engine.initialized).toBe(true)
+            expect(engine.initOptions).toBe(options)
+        })
+
+        test('supports async init', async () => {
+            registry.register('deckgl', createAsyncMockAdapterClass())
+            const engine = registry.createEngine('deckgl')
+            const options = { containerId: 'map' }
+
+            await registry.initializeEngine(engine, options)
+
+            expect(engine.initialized).toBe(true)
+        })
+    })
+
+    test.describe('destroyEngine', () => {
+        test('calls destroy on the engine', () => {
+            registry.register('leaflet', createMockAdapterClass())
+            const engine = registry.createEngine('leaflet')
+
+            registry.destroyEngine(engine)
+
+            expect(engine.destroyed).toBe(true)
+        })
+
+        test('removes the engine from tracked engines', () => {
+            registry.register('leaflet', createMockAdapterClass())
+            const engine = registry.createEngine('leaflet')
+
+            registry.destroyEngine(engine)
+
+            expect(registry.getEngine('leaflet')).toBeUndefined()
+        })
+
+        test('clears activeEngine if the destroyed engine was active', () => {
+            registry.register('leaflet', createMockAdapterClass())
+            const engine = registry.createEngine('leaflet')
+            registry.setActiveEngine(engine)
+
+            registry.destroyEngine(engine)
+
+            expect(registry.getActiveEngine()).toBeNull()
+        })
+
+        test('supports async destroy', async () => {
+            registry.register('deckgl', createAsyncMockAdapterClass())
+            const engine = registry.createEngine('deckgl')
+
+            await registry.destroyEngine(engine)
+
+            expect(engine.destroyed).toBe(true)
+        })
+    })
+
+    test.describe('active engine management', () => {
+        test('active engine is null by default', () => {
+            expect(registry.getActiveEngine()).toBeNull()
+        })
+
+        test('setActiveEngine stores the engine', () => {
+            registry.register('leaflet', createMockAdapterClass())
+            const engine = registry.createEngine('leaflet')
+
+            registry.setActiveEngine(engine)
+
+            expect(registry.getActiveEngine()).toBe(engine)
+        })
+    })
+
+    test.describe('hasEngine', () => {
+        test('returns false for unregistered name', () => {
+            expect(registry.hasEngine('leaflet')).toBe(false)
+        })
+
+        test('returns true for registered name', () => {
+            registry.register('leaflet', createMockAdapterClass())
+            expect(registry.hasEngine('leaflet')).toBe(true)
+        })
+    })
+
+    test.describe('getRegisteredEngines', () => {
+        test('returns empty array when nothing is registered', () => {
+            expect(registry.getRegisteredEngines()).toEqual([])
+        })
+
+        test('returns all registered engine names', () => {
+            registry.register('leaflet', createMockAdapterClass())
+            registry.register('deckgl', createAsyncMockAdapterClass())
+
+            const names = registry.getRegisteredEngines()
+            expect(names).toContain('leaflet')
+            expect(names).toContain('deckgl')
+            expect(names.length).toBe(2)
+        })
+    })
+
+    test.describe('getEngine', () => {
+        test('returns undefined for uncreated engine', () => {
+            expect(registry.getEngine('leaflet')).toBeUndefined()
+        })
+
+        test('returns the created engine instance', () => {
+            registry.register('leaflet', createMockAdapterClass())
+            const engine = registry.createEngine('leaflet')
+
+            expect(registry.getEngine('leaflet')).toBe(engine)
+        })
+    })
+})


### PR DESCRIPTION
Closes: https://github.com/NASA-IMPACT/MMGIS/issues/15

Add `MapEngineRegistry` class as a central registry for managing map engine adapter classes and their lifecycle in MMGIS.

I left out `switchEngine()` mentioned in the original GH ticket. This is because each mission for now will be configured with a single engine at creation time and cannot change it afterward, so there is no runtime switching to support.

We track the "active engine" via setActiveEngine() and getActiveEngine() to give the rest of the application a single source of truth for which engine is currently running.

Once `LeafletAdapter` and `DeckGLAdapter` are implemented, we should register them at application startup with the engine name they correspond to. The mission config then should determine which name is passed to `createEngine()` and the registry returns a fully constructed adapter instance. From that point on, the rest of the app interacts only through the `IMapEngine` interface without needing to know which engine is underneath.

eg. simple usage:

```
mapEngineRegistry.register(MAP_ENGINE.LEAFLET, LeafletAdapter)
mapEngineRegistry.register(MAP_ENGINE.DECKGL, DeckGLAdapter)

const engine = mapEngineRegistry.createEngine(mission.engine, options)
await mapEngineRegistry.initializeEngine(engine, options)
mapEngineRegistry.setActiveEngine(engine)
```
### How to test

Unit tests cover all public registry methods.

