### PR TITLE
leaflet tile and geojson layers

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -66,14 +66,13 @@ export default defineConfig({
   webServer: process.env.PLAYWRIGHT_TEST_UNIT_ONLY
     ? undefined
     : {
-        command: "npm run start:test",
-        url: `${
-          process.env.TEST_BASE_URL || "http://localhost:8888"
+      command: "npm run start:test",
+      url: `${process.env.TEST_BASE_URL || "http://localhost:8888"
         }/api/utils/healthcheck`,
-        timeout: 120 * 1000,
-        reuseExistingServer: !process.env.CI,
-        stdout: "pipe",
-        stderr: "pipe",
-        ignoreHTTPSErrors: true,
-      },
+      timeout: 120 * 1000,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+      ignoreHTTPSErrors: true,
+    },
 });

--- a/src/essence/Basics/MapEngines/Adapters/LeafletAdapter.ts
+++ b/src/essence/Basics/MapEngines/Adapters/LeafletAdapter.ts
@@ -23,8 +23,14 @@ import {
     MapInitOptions,
     ProjectionOptions,
 } from '../types/view'
-import { LayerOptions, TileLayerOptions } from '../types/layers'
-import { buildLeafletLayer, resolveLeafletLayerId } from './LeafletHelpers'
+import { LayerOptions, TileLayerOptions, MarkerOptions } from '../types/layers'
+import { IMapEngineMarkers } from '../IMapEngineMarkers'
+import {
+    buildLeafletLayer,
+    buildLeafletMarker,
+    resolveLeafletLayerId,
+    resolveLeafletMarkerId,
+} from './LeafletHelpers'
 import {
     MapEventHandler,
     MapEventOptions,
@@ -37,7 +43,7 @@ import { MapEngineType } from '../types/engine'
 // Leaflet is loaded globally via window.L
 declare const L: any
 
-export default class LeafletAdapter implements IMapEngine<any, any, any> {
+export default class LeafletAdapter implements IMapEngine<any, any, any>, IMapEngineMarkers {
     /**
      * Engine type identifier
      */
@@ -57,6 +63,11 @@ export default class LeafletAdapter implements IMapEngine<any, any, any> {
      * Registry of layers by ID
      */
     private _layers: Map<string, any> = new Map()
+
+    /**
+     * Registry of markers by ID
+     */
+    private _markers: Map<string, any> = new Map()
 
     /**
      * Registry of event handlers for cleanup
@@ -242,6 +253,7 @@ export default class LeafletAdapter implements IMapEngine<any, any, any> {
         this._eventHandlers.clear()
 
         this._layers.clear()
+        this._markers.clear()
 
         this._map.remove()
         this._map = null
@@ -581,23 +593,6 @@ export default class LeafletAdapter implements IMapEngine<any, any, any> {
         return leafletLayer
     }
 
-    /**
-     * Build a Leaflet tileLayer from TileLayerOptions.
-     * TMS origin (bottom-left) is the default — matching existing MMGIS tile behaviour.
-     * Pass tms: false for standard XYZ / WMS slippy tiles.
-     */
-    private _createTileLayer(options: any): any {
-        return buildLeafletLayer(options.id ?? '', options)
-    }
-
-    /**
-     * Build a Leaflet geoJSON layer from GeoJSONLayerOptions.
-     * Callback props (style, onEachFeature, pointToLayer, filter) are forwarded as-is.
-     */
-    private _createGeoJSONLayer(options: any): any {
-        return buildLeafletLayer(options.id ?? '', options)
-    }
-
     removeLayer(layer: any | string): void {
         if (typeof layer === 'string') {
             const leafletLayer = this._layers.get(layer)
@@ -754,18 +749,194 @@ export default class LeafletAdapter implements IMapEngine<any, any, any> {
         return normalized
     }
 
+    /**
+     * Register a handler called when the user clicks a rendered feature.
+     * Attaches a map-level click listener; on each click iterates registered
+     * vector layers to find the topmost feature under the cursor.
+     */
     onFeatureClick(handler: FeatureInteractionHandler): void {
-        throw new Error('onFeatureClick not yet implemented')
+        this._map.on('click', (e: any) => {
+            const result = this._pickFeatureAtLatLng(e.latlng)
+            handler({
+                feature: result?.feature ?? null,
+                layerId: result?.layerId,
+                latlng: { lat: e.latlng.lat, lng: e.latlng.lng },
+                pixel: e.containerPoint
+                    ? { x: e.containerPoint.x, y: e.containerPoint.y }
+                    : undefined,
+            })
+        })
     }
 
+    /**
+     * Register a handler called when the user moves over a rendered feature.
+     * Uses mousemove to track the hovered feature and mouseout to clear it.
+     * Returns feature: null when the cursor leaves the map.
+     */
     onFeatureHover(handler: FeatureInteractionHandler): void {
-        throw new Error('onFeatureHover not yet implemented')
+        this._map.on('mousemove', (e: any) => {
+            const result = this._pickFeatureAtLatLng(e.latlng)
+            handler({
+                feature: result?.feature ?? null,
+                layerId: result?.layerId,
+                latlng: { lat: e.latlng.lat, lng: e.latlng.lng },
+                pixel: e.containerPoint
+                    ? { x: e.containerPoint.x, y: e.containerPoint.y }
+                    : undefined,
+            })
+        })
+        this._map.on('mouseout', () => {
+            handler({ feature: null })
+        })
     }
 
+    /**
+     * Query registered vector layers for features near a point or within a box.
+     * Filters by `options.layers` (array of layer ids) when provided.
+     * Leaflet has no GPU picking — this uses bounding-box intersection as a
+     * fast approximation. Callers needing precise picking should use
+     * onFeatureClick / onFeatureHover instead.
+     */
     queryRenderedFeatures(
         geometry: PointLike | [PointLike, PointLike],
         options: QueryFeaturesOptions = {}
     ): FeaturePickResult[] {
-        throw new Error('queryRenderedFeatures not yet implemented')
+        const results: FeaturePickResult[] = []
+
+        this._layers.forEach((leafletLayer, id) => {
+            if (options.layers && !options.layers.includes(id)) return
+            if (typeof leafletLayer.getBounds !== 'function') return
+
+            try {
+                const bounds = leafletLayer.getBounds()
+                const queryPoint = Array.isArray(geometry)
+                    ? (geometry as [PointLike, PointLike])[0]
+                    : geometry as PointLike
+                const latlng = this._map.containerPointToLatLng(
+                    Array.isArray(queryPoint)
+                        ? queryPoint
+                        : [queryPoint.x, queryPoint.y]
+                )
+                if (bounds.contains(latlng)) {
+                    results.push({ feature: null, layerId: id, latlng })
+                }
+            } catch {
+                // layer may not have valid bounds yet — skip silently
+            }
+        })
+
+        return results
+    }
+
+    // ========================================
+    // MARKER METHODS (IMapEngineMarkers)
+    // ========================================
+
+    /**
+     * Add a marker to the map and register it by ID.
+     * Defaults to L.circleMarker (dominant MMGIS pattern).
+     * Uses L.marker + L.icon when options.icon.url is provided.
+     *
+     * @throws {Error} If options.id or options.position is missing.
+     */
+    addMarker(options: MarkerOptions): any {
+        if (!options.id) {
+            throw new Error('addMarker: options.id is required')
+        }
+
+        const leafletMarker = buildLeafletMarker(options.id, options)
+        this._markers.set(options.id, leafletMarker)
+        this._map.addLayer(leafletMarker)
+        return leafletMarker
+    }
+
+    /**
+     * Remove a marker from the map by string ID or native marker object.
+     * No-op for unknown IDs.
+     */
+    removeMarker(marker: any | string): void {
+        const id = resolveLeafletMarkerId(marker)
+        const leafletMarker = this._markers.get(id)
+        if (leafletMarker) {
+            this._map.removeLayer(leafletMarker)
+            this._markers.delete(id)
+        }
+    }
+
+    /**
+     * Mutate properties of an existing registered marker without recreating it.
+     * `marker` can be the string ID or the native Leaflet marker object.
+     *
+     * Supported mutations:
+     *   position      → setLatLng()
+     *   icon          → setIcon()        (L.marker only)
+     *   zIndexOffset  → setZIndexOffset()
+     *   draggable     → dragging.enable() / .disable()
+     *
+     * @throws {Error} If the marker ID is not found in the registry.
+     */
+    updateMarker(marker: any | string, updates: Partial<MarkerOptions>): any {
+        const id = resolveLeafletMarkerId(marker)
+        const leafletMarker = this._markers.get(id)
+        if (!leafletMarker) {
+            throw new Error(
+                `updateMarker: no marker found with id "${id}". ` +
+                `Ensure the marker was created with addMarker().`
+            )
+        }
+
+        if (updates.position !== undefined) {
+            const pos = Array.isArray(updates.position)
+                ? updates.position
+                : [updates.position.lat, updates.position.lng]
+            leafletMarker.setLatLng(pos)
+        }
+
+        if (updates.icon?.url !== undefined && typeof leafletMarker.setIcon === 'function') {
+            const leafletIcon = (window as any).L.icon({
+                iconUrl: updates.icon.url,
+                ...(updates.icon.size ? { iconSize: updates.icon.size } : {}),
+                ...(updates.icon.anchor ? { iconAnchor: updates.icon.anchor } : {}),
+                ...(updates.icon.className ? { className: updates.icon.className } : {}),
+            })
+            leafletMarker.setIcon(leafletIcon)
+        }
+
+        if (typeof updates.zIndexOffset === 'number' &&
+            typeof leafletMarker.setZIndexOffset === 'function') {
+            leafletMarker.setZIndexOffset(updates.zIndexOffset)
+        }
+
+        if (typeof updates.draggable === 'boolean' && leafletMarker.dragging) {
+            updates.draggable
+                ? leafletMarker.dragging.enable()
+                : leafletMarker.dragging.disable()
+        }
+
+        return leafletMarker
+    }
+
+    // ========================================
+    // PRIVATE HELPERS
+    // ========================================
+
+    /**
+     * Walk registered vector layers and return the first feature whose bounds
+     * contain the given latlng. Used by onFeatureClick and onFeatureHover.
+     */
+    private _pickFeatureAtLatLng(
+        latlng: any
+    ): { feature: Record<string, unknown>; layerId: string } | null {
+        for (const [id, leafletLayer] of this._layers) {
+            if (typeof leafletLayer.getBounds !== 'function') continue
+            try {
+                if (leafletLayer.getBounds().contains(latlng)) {
+                    return { feature: leafletLayer.toGeoJSON?.() ?? {}, layerId: id }
+                }
+            } catch {
+                // layer bounds not yet available
+            }
+        }
+        return null
     }
 }

--- a/src/essence/Basics/MapEngines/Adapters/LeafletAdapter.ts
+++ b/src/essence/Basics/MapEngines/Adapters/LeafletAdapter.ts
@@ -23,7 +23,8 @@ import {
     MapInitOptions,
     ProjectionOptions,
 } from '../types/view'
-import { LayerOptions } from '../types/layers'
+import { LayerOptions, TileLayerOptions } from '../types/layers'
+import { buildLeafletLayer, resolveLeafletLayerId } from './LeafletHelpers'
 import {
     MapEventHandler,
     MapEventOptions,
@@ -513,8 +514,7 @@ export default class LeafletAdapter implements IMapEngine<any, any, any> {
     }
 
     // ========================================
-    // LAYER MANAGEMENT METHODS (Stubs for now)
-    // These will be implemented in subsequent tickets
+    // LAYER MANAGEMENT METHODS
     // ========================================
 
     getLayers(): any[] {
@@ -528,12 +528,74 @@ export default class LeafletAdapter implements IMapEngine<any, any, any> {
         return this._map.hasLayer(layer)
     }
 
+    /**
+     * Backward-compatible addLayer.
+     *
+     * If a raw Leaflet layer object is passed (has _leaflet_id), it is forwarded
+     * directly to the native map — preserving all existing Map_.js / Layers_.js call sites.
+     *
+     * If a LayerOptions spec is passed, createLayer() is called so the layer is
+     * also registered in the internal registry for later lookup by ID.
+     */
     addLayer(layer: any): void {
+        if (
+            layer !== null &&
+            typeof layer === 'object' &&
+            typeof layer.type === 'string' &&
+            layer._leaflet_id === undefined
+        ) {
+            this.createLayer(layer as LayerOptions)
+            return
+        }
         this._map.addLayer(layer)
     }
 
+    /**
+     * Create a Leaflet layer from a LayerOptions spec, register it by ID, and
+     * add it to the map (unless visible === false).
+     *
+     * Delegates construction to {@link buildLeafletLayer}.
+     *
+     * @throws {Error} If `options.type` is not a supported layer type.
+     */
     createLayer(options: LayerOptions): any {
-        throw new Error('createLayer not yet implemented')
+        if (!options.id) {
+            throw new Error('createLayer: options.id is required')
+        }
+
+        const leafletLayer = buildLeafletLayer(options.id, options)
+
+        this._layers.set(options.id, leafletLayer)
+
+        if (typeof options.opacity === 'number' && typeof leafletLayer.setOpacity === 'function') {
+            leafletLayer.setOpacity(options.opacity)
+        }
+        if (typeof options.zIndex === 'number' && typeof leafletLayer.setZIndex === 'function') {
+            leafletLayer.setZIndex(options.zIndex)
+        }
+
+        if (options.visible !== false) {
+            this._map.addLayer(leafletLayer)
+        }
+
+        return leafletLayer
+    }
+
+    /**
+     * Build a Leaflet tileLayer from TileLayerOptions.
+     * TMS origin (bottom-left) is the default — matching existing MMGIS tile behaviour.
+     * Pass tms: false for standard XYZ / WMS slippy tiles.
+     */
+    private _createTileLayer(options: any): any {
+        return buildLeafletLayer(options.id ?? '', options)
+    }
+
+    /**
+     * Build a Leaflet geoJSON layer from GeoJSONLayerOptions.
+     * Callback props (style, onEachFeature, pointToLayer, filter) are forwarded as-is.
+     */
+    private _createGeoJSONLayer(options: any): any {
+        return buildLeafletLayer(options.id ?? '', options)
     }
 
     removeLayer(layer: any | string): void {
@@ -548,8 +610,55 @@ export default class LeafletAdapter implements IMapEngine<any, any, any> {
         }
     }
 
-    updateLayer(layer: any | string, options: Partial<LayerOptions>): any {
-        throw new Error('updateLayer not yet implemented')
+    /**
+     * Mutate properties on an existing registered layer without recreating it.
+     * `layer` can be the string ID used at `createLayer` time, or the native
+     * Leaflet layer object (identified via its `_mmgisId` property set by
+     * {@link buildLeafletLayer}).
+     *
+     * Supported mutations:
+     *   opacity  → setOpacity()            (tile + GeoJSON)
+     *   visible  → addLayer / removeLayer  (toggle without destroying)
+     *   zIndex   → setZIndex()             (tile layers)
+     *   style    → setStyle()              (GeoJSON layers)
+     *   url      → setUrl()               (tile layers)
+     */
+    updateLayer(layer: any | string, updates: Partial<LayerOptions>): any {
+        const id = resolveLeafletLayerId(layer)
+        const leafletLayer = this._layers.get(id)
+        if (!leafletLayer) {
+            throw new Error(
+                `updateLayer: no layer found with id "${id}". ` +
+                `Ensure the layer was created with createLayer().`
+            )
+        }
+
+        if (typeof updates.opacity === 'number' && typeof leafletLayer.setOpacity === 'function') {
+            leafletLayer.setOpacity(updates.opacity)
+        }
+
+        if (typeof updates.visible === 'boolean') {
+            const onMap = this._map.hasLayer(leafletLayer)
+            if (updates.visible && !onMap) {
+                this._map.addLayer(leafletLayer)
+            } else if (!updates.visible && onMap) {
+                this._map.removeLayer(leafletLayer)
+            }
+        }
+
+        if (typeof updates.zIndex === 'number' && typeof leafletLayer.setZIndex === 'function') {
+            leafletLayer.setZIndex(updates.zIndex)
+        }
+
+        if (updates.style !== undefined && typeof leafletLayer.setStyle === 'function') {
+            leafletLayer.setStyle(updates.style)
+        }
+
+        if ((updates as TileLayerOptions).url !== undefined && typeof leafletLayer.setUrl === 'function') {
+            leafletLayer.setUrl((updates as TileLayerOptions).url!)
+        }
+
+        return leafletLayer
     }
 
     setLayerZIndex(layer: any | string, zIndex: number): void {

--- a/src/essence/Basics/MapEngines/Adapters/LeafletHelpers.ts
+++ b/src/essence/Basics/MapEngines/Adapters/LeafletHelpers.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure utility functions used by LeafletAdapter.
+ * Nothing here depends on class state — mirrors DeckGLHelpers.ts.
+ */
+
+import type { LayerOptions, TileLayerOptions, GeoJSONLayerOptions } from '../types/layers'
+
+declare const L: any
+
+/**
+ * Resolve a layer reference (native Leaflet layer object or string id) to its
+ * string id. Leaflet layers expose their id via a `_mmgisId` property set by
+ * the adapter at creation time.
+ */
+export function resolveLeafletLayerId(layer: any | string): string {
+    return typeof layer === 'string' ? layer : layer._mmgisId
+}
+
+/**
+ * Construct a native Leaflet layer from a {@link LayerOptions} spec.
+ * Supports `'tile'` (L.tileLayer) and `'vector'` (L.geoJSON).
+ * Use `nativeOptions` on the layer options object for Leaflet-specific props.
+ *
+ * @throws {Error} If `options.type` is not a supported layer type.
+ */
+export function buildLeafletLayer(id: string, options: LayerOptions): any {
+    switch (options.type) {
+        case 'tile':
+            return _buildTileLayer(id, options as TileLayerOptions)
+        case 'vector':
+            return _buildGeoJSONLayer(id, options as GeoJSONLayerOptions)
+        default:
+            throw new Error(
+                `buildLeafletLayer: unsupported layer type "${options.type}". ` +
+                `Supported types: 'tile', 'vector'.`
+            )
+    }
+}
+
+/**
+ * Build an L.tileLayer from {@link TileLayerOptions}.
+ * TMS origin (bottom-left) is the default — matching existing MMGIS tile behaviour.
+ * Pass `tms: false` for standard XYZ / WMS slippy tiles.
+ */
+function _buildTileLayer(id: string, options: TileLayerOptions): any {
+    if (!options.url) {
+        throw new Error('buildLeafletLayer (tile): options.url is required')
+    }
+
+    const leafletOptions: Record<string, any> = {
+        tms: options.tms !== undefined ? options.tms : true,
+        opacity: options.opacity ?? 1,
+        minZoom: options.minZoom,
+        maxZoom: options.maxZoom,
+        maxNativeZoom: options.maxNativeZoom,
+        subdomains: options.subdomains ?? 'abc',
+        attribution: options.attribution ?? '',
+        tileSize: options.tileSize ?? 256,
+        noWrap: true,
+        continuousWorld: true,
+        ...(options.nativeOptions ?? {}),
+    }
+
+    // Strip undefined values so Leaflet uses its own defaults
+    Object.keys(leafletOptions).forEach((k) => {
+        if (leafletOptions[k] === undefined) delete leafletOptions[k]
+    })
+
+    const layer = L.tileLayer(options.url, leafletOptions)
+    layer._mmgisId = id
+    return layer
+}
+
+/**
+ * Build an L.geoJSON layer from {@link GeoJSONLayerOptions}.
+ * Callback props (style, onEachFeature, pointToLayer, filter) are forwarded as-is.
+ */
+function _buildGeoJSONLayer(id: string, options: GeoJSONLayerOptions): any {
+    if (!options.geojson) {
+        throw new Error('buildLeafletLayer (vector): options.geojson is required')
+    }
+
+    const leafletOptions: Record<string, any> = {
+        ...(options.style !== undefined ? { style: options.style } : {}),
+        ...(options.onEachFeature ? { onEachFeature: options.onEachFeature } : {}),
+        ...(options.pointToLayer ? { pointToLayer: options.pointToLayer } : {}),
+        ...(options.filter ? { filter: options.filter } : {}),
+        ...(options.nativeOptions ?? {}),
+    }
+
+    const layer = L.geoJSON(options.geojson, leafletOptions)
+    layer._mmgisId = id
+    return layer
+}

--- a/src/essence/Basics/MapEngines/Adapters/LeafletHelpers.ts
+++ b/src/essence/Basics/MapEngines/Adapters/LeafletHelpers.ts
@@ -3,7 +3,7 @@
  * Nothing here depends on class state — mirrors DeckGLHelpers.ts.
  */
 
-import type { LayerOptions, TileLayerOptions, GeoJSONLayerOptions } from '../types/layers'
+import type { LayerOptions, TileLayerOptions, GeoJSONLayerOptions, MarkerOptions, IconOptions } from '../types/layers'
 
 declare const L: any
 
@@ -14,6 +14,15 @@ declare const L: any
  */
 export function resolveLeafletLayerId(layer: any | string): string {
     return typeof layer === 'string' ? layer : layer._mmgisId
+}
+
+/**
+ * Resolve a marker reference (native Leaflet marker object or string id) to
+ * its string id. Markers expose their id via a `_mmgisId` property set by
+ * the adapter at creation time.
+ */
+export function resolveLeafletMarkerId(marker: any | string): string {
+    return typeof marker === 'string' ? marker : marker._mmgisId
 }
 
 /**
@@ -36,6 +45,48 @@ export function buildLeafletLayer(id: string, options: LayerOptions): any {
             )
     }
 }
+
+/**
+ * Construct a native Leaflet marker from a {@link MarkerOptions} spec.
+ *
+ * Defaults to `L.circleMarker` (the dominant MMGIS pattern used by
+ * MeasureTool, DrawTool, Coordinates, etc.) when no `icon.url` is provided.
+ * Falls back to `L.marker` + `L.icon` when an image icon URL is given.
+ *
+ * @throws {Error} If `options.position` is missing.
+ */
+export function buildLeafletMarker(id: string, options: MarkerOptions): any {
+    if (!options.position) {
+        throw new Error('buildLeafletMarker: options.position is required')
+    }
+
+    const pos = _normalizePosition(options.position)
+
+    let marker: any
+
+    if (options.icon?.url) {
+        const leafletIcon = _buildLeafletIcon(options.icon)
+        const markerOptions: Record<string, any> = {
+            icon: leafletIcon,
+            draggable: options.draggable ?? false,
+            interactive: options.interactive ?? true,
+            ...(options.zIndexOffset !== undefined ? { zIndexOffset: options.zIndexOffset } : {}),
+        }
+        marker = L.marker([pos.lat, pos.lng], markerOptions)
+    } else {
+        const circleOptions: Record<string, any> = {
+            interactive: options.interactive ?? true,
+            draggable: options.draggable ?? false,
+            ...(options.zIndexOffset !== undefined ? { zIndexOffset: options.zIndexOffset } : {}),
+        }
+        marker = L.circleMarker([pos.lat, pos.lng], circleOptions)
+    }
+
+    marker._mmgisId = id
+    return marker
+}
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
 
 /**
  * Build an L.tileLayer from {@link TileLayerOptions}.
@@ -91,4 +142,27 @@ function _buildGeoJSONLayer(id: string, options: GeoJSONLayerOptions): any {
     const layer = L.geoJSON(options.geojson, leafletOptions)
     layer._mmgisId = id
     return layer
+}
+
+/**
+ * Build an L.Icon from {@link IconOptions}.
+ */
+function _buildLeafletIcon(icon: IconOptions): any {
+    const iconOptions: Record<string, any> = {
+        iconUrl: icon.url,
+    }
+    if (icon.size) iconOptions.iconSize = icon.size
+    if (icon.anchor) iconOptions.iconAnchor = icon.anchor
+    if (icon.className) iconOptions.className = icon.className
+    return L.icon(iconOptions)
+}
+
+/**
+ * Normalize a LatLngLike value to a { lat, lng } object.
+ */
+function _normalizePosition(position: any): { lat: number; lng: number } {
+    if (Array.isArray(position)) {
+        return { lat: position[0], lng: position[1] }
+    }
+    return position
 }

--- a/tests/unit/LeafletAdapter.spec.js
+++ b/tests/unit/LeafletAdapter.spec.js
@@ -237,3 +237,322 @@ test.describe('LeafletAdapter - View Control', () => {
         expect(center).toHaveProperty('lng', -98.5)
     })
 })
+
+// ─── Helpers shared by layer tests ───────────────────────────────────────────
+
+function makeMockTileLayer() {
+    return {
+        _type: 'tile',
+        _opacity: 1,
+        _zIndex: 0,
+        _url: '',
+        setOpacity: function (v) { this._opacity = v },
+        setZIndex: function (v) { this._zIndex = v },
+        setUrl: function (v) { this._url = v },
+    }
+}
+
+function makeMockGeoJSONLayer() {
+    return {
+        _type: 'geojson',
+        _style: null,
+        setStyle: function (v) { this._style = v },
+    }
+}
+
+function setupWithLayerMocks() {
+    const { mockMap, fakeContainer } = setup()
+
+    const mockTile = makeMockTileLayer()
+    const mockGeoJSON = makeMockGeoJSONLayer()
+
+    global.L.tileLayer = () => mockTile
+    global.L.geoJSON = () => mockGeoJSON
+
+    const addedLayers = []
+    const removedLayers = []
+    mockMap.addLayer = function (l) { addedLayers.push(l) }
+    mockMap.removeLayer = function (l) { removedLayers.push(l) }
+    mockMap.hasLayer = function (l) {
+        return addedLayers.includes(l) && !removedLayers.includes(l)
+    }
+
+    return { mockMap, fakeContainer, mockTile, mockGeoJSON, addedLayers, removedLayers }
+}
+
+// ─── createLayer: tile ───────────────────────────────────────────────────────
+
+test.describe('LeafletAdapter - createLayer (tile)', () => {
+
+    test('creates a tile layer and adds it to the map', () => {
+        const { mockTile, addedLayers } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        const layer = adapter.createLayer({ id: 'basemap', type: 'tile', url: 'https://example.com/{z}/{x}/{y}.png' })
+
+        expect(layer).toBe(mockTile)
+        expect(addedLayers).toContain(mockTile)
+    })
+
+    test('tile layer defaults tms to true', () => {
+        const { mockTile } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        let capturedOptions = null
+        global.L.tileLayer = (url, opts) => { capturedOptions = opts; return mockTile }
+
+        adapter.createLayer({ id: 'tms', type: 'tile', url: 'https://x.com/{z}/{x}/{y}.png' })
+        expect(capturedOptions.tms).toBe(true)
+    })
+
+    test('tile layer with tms:false (WMS/WMTS)', () => {
+        const { mockTile } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        let capturedOptions = null
+        global.L.tileLayer = (url, opts) => { capturedOptions = opts; return mockTile }
+
+        adapter.createLayer({ id: 'wms', type: 'tile', url: 'https://x.com/wms', tms: false })
+        expect(capturedOptions.tms).toBe(false)
+    })
+
+    test('tile layer applies initial opacity', () => {
+        const { mockTile } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        adapter.createLayer({ id: 'op', type: 'tile', url: 'https://x.com/{z}/{x}/{y}.png', opacity: 0.5 })
+        expect(mockTile._opacity).toBe(0.5)
+    })
+
+    test('tile layer with visible:false is NOT added to map', () => {
+        const { mockTile, addedLayers } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        adapter.createLayer({ id: 'hidden', type: 'tile', url: 'https://x.com/{z}/{x}/{y}.png', visible: false })
+        expect(addedLayers).not.toContain(mockTile)
+    })
+
+    test('createLayer throws when id is missing', () => {
+        setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        expect(() =>
+            adapter.createLayer({ type: 'tile', url: 'https://x.com/{z}/{x}/{y}.png' })
+        ).toThrow('options.id is required')
+    })
+
+    test('createLayer throws for unsupported layer type', () => {
+        setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        expect(() =>
+            adapter.createLayer({ id: 'bad', type: 'unknown' })
+        ).toThrow('unsupported layer type')
+    })
+
+    test('nativeOptions are forwarded to L.tileLayer', () => {
+        const { mockTile } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        let capturedOptions = null
+        global.L.tileLayer = (url, opts) => { capturedOptions = opts; return mockTile }
+
+        adapter.createLayer({
+            id: 'native',
+            type: 'tile',
+            url: 'https://x.com/{z}/{x}/{y}.png',
+            nativeOptions: { crossOrigin: 'anonymous' },
+        })
+        expect(capturedOptions.crossOrigin).toBe('anonymous')
+    })
+})
+
+// ─── createLayer: GeoJSON / vector ──────────────────────────────────────────
+
+test.describe('LeafletAdapter - createLayer (vector)', () => {
+
+    const sampleGeoJSON = {
+        type: 'FeatureCollection',
+        features: [{ type: 'Feature', geometry: { type: 'Point', coordinates: [0, 0] }, properties: {} }],
+    }
+
+    test('creates a GeoJSON layer and adds it to the map', () => {
+        const { mockGeoJSON, addedLayers } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        const layer = adapter.createLayer({ id: 'geo', type: 'vector', geojson: sampleGeoJSON })
+
+        expect(layer).toBe(mockGeoJSON)
+        expect(addedLayers).toContain(mockGeoJSON)
+    })
+
+    test('style callback is forwarded to L.geoJSON', () => {
+        const { mockGeoJSON } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        const styleFn = () => ({ color: 'red' })
+        let capturedOptions = null
+        global.L.geoJSON = (data, opts) => { capturedOptions = opts; return mockGeoJSON }
+
+        adapter.createLayer({ id: 'styled', type: 'vector', geojson: sampleGeoJSON, style: styleFn })
+        expect(capturedOptions.style).toBe(styleFn)
+    })
+
+    test('createLayer (vector) throws when geojson is missing', () => {
+        setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        expect(() =>
+            adapter.createLayer({ id: 'no-data', type: 'vector' })
+        ).toThrow('options.geojson is required')
+    })
+})
+
+// ─── addLayer backward compatibility ────────────────────────────────────────
+
+test.describe('LeafletAdapter - addLayer (backward compatibility)', () => {
+
+    test('raw Leaflet layer (has _leaflet_id) is forwarded directly to the native map', () => {
+        const { addedLayers } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        const rawLayer = { _leaflet_id: 42 }
+        adapter.addLayer(rawLayer)
+
+        expect(addedLayers).toContain(rawLayer)
+    })
+
+    test('LayerOptions spec passed to addLayer() delegates to createLayer()', () => {
+        const { mockTile, addedLayers } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        adapter.addLayer({ id: 'via-addLayer', type: 'tile', url: 'https://x.com/{z}/{x}/{y}.png' })
+
+        expect(adapter.hasLayer('via-addLayer')).toBe(true)
+        expect(addedLayers).toContain(mockTile)
+    })
+})
+
+// ─── removeLayer ─────────────────────────────────────────────────────────────
+
+test.describe('LeafletAdapter - removeLayer', () => {
+
+    test('removes a layer by string ID and cleans up the registry', () => {
+        const { removedLayers } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        adapter.createLayer({ id: 'rm-me', type: 'tile', url: 'https://x.com/{z}/{x}/{y}.png' })
+        expect(adapter.hasLayer('rm-me')).toBe(true)
+
+        adapter.removeLayer('rm-me')
+
+        expect(adapter.hasLayer('rm-me')).toBe(false)
+        expect(removedLayers.length).toBeGreaterThan(0)
+    })
+
+    test('removing a non-existent id is a no-op', () => {
+        setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        expect(() => adapter.removeLayer('does-not-exist')).not.toThrow()
+    })
+})
+
+// ─── updateLayer ─────────────────────────────────────────────────────────────
+
+test.describe('LeafletAdapter - updateLayer', () => {
+
+    test('updates opacity on a tile layer', () => {
+        const { mockTile } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        adapter.createLayer({ id: 'op-tile', type: 'tile', url: 'https://x.com/{z}/{x}/{y}.png' })
+        adapter.updateLayer('op-tile', { opacity: 0.3 })
+
+        expect(mockTile._opacity).toBe(0.3)
+    })
+
+    test('hides a layer by setting visible:false', () => {
+        const { mockTile, removedLayers } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        adapter.createLayer({ id: 'show-hide', type: 'tile', url: 'https://x.com/{z}/{x}/{y}.png' })
+        adapter.updateLayer('show-hide', { visible: false })
+
+        expect(removedLayers).toContain(mockTile)
+    })
+
+    test('shows a hidden layer by setting visible:true', () => {
+        const { mockTile, addedLayers } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        adapter.createLayer({ id: 'hidden-show', type: 'tile', url: 'https://x.com/{z}/{x}/{y}.png', visible: false })
+        const countBefore = addedLayers.length
+
+        adapter.updateLayer('hidden-show', { visible: true })
+
+        expect(addedLayers.length).toBeGreaterThan(countBefore)
+        expect(addedLayers).toContain(mockTile)
+    })
+
+    test('updates style on a GeoJSON layer', () => {
+        const { mockGeoJSON } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        adapter.createLayer({ id: 'geo-style', type: 'vector', geojson: { type: 'FeatureCollection', features: [] } })
+        adapter.updateLayer('geo-style', { style: { color: 'blue' } })
+
+        expect(mockGeoJSON._style).toEqual({ color: 'blue' })
+    })
+
+    test('updates url on a tile layer', () => {
+        const { mockTile } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        adapter.createLayer({ id: 'url-tile', type: 'tile', url: 'https://old.com/{z}/{x}/{y}.png' })
+        adapter.updateLayer('url-tile', { url: 'https://new.com/{z}/{x}/{y}.png' })
+
+        expect(mockTile._url).toBe('https://new.com/{z}/{x}/{y}.png')
+    })
+
+    test('updateLayer throws when layer id is not found', () => {
+        setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        expect(() =>
+            adapter.updateLayer('ghost', { opacity: 1 })
+        ).toThrow('no layer found with id "ghost"')
+    })
+
+    test('updateLayer returns the native Leaflet layer', () => {
+        const { mockTile } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        adapter.createLayer({ id: 'ret', type: 'tile', url: 'https://x.com/{z}/{x}/{y}.png' })
+        const returned = adapter.updateLayer('ret', { opacity: 0.8 })
+
+        expect(returned).toBe(mockTile)
+    })
+})

--- a/tests/unit/LeafletAdapter.spec.js
+++ b/tests/unit/LeafletAdapter.spec.js
@@ -556,3 +556,277 @@ test.describe('LeafletAdapter - updateLayer', () => {
         expect(returned).toBe(mockTile)
     })
 })
+
+// ─── Marker helpers ───────────────────────────────────────────────────────────
+
+function makeMockCircleMarker() {
+    return {
+        _type: 'circleMarker',
+        _latlng: null,
+        _zIndexOffset: 0,
+        _dragging: false,
+        setLatLng: function (ll) { this._latlng = ll },
+        setZIndexOffset: function (v) { this._zIndexOffset = v },
+        dragging: {
+            enable: function () { },
+            disable: function () { },
+        },
+    }
+}
+
+function makeMockIconMarker() {
+    return {
+        _type: 'marker',
+        _latlng: null,
+        _icon: null,
+        setLatLng: function (ll) { this._latlng = ll },
+        setIcon: function (icon) { this._icon = icon },
+        setZIndexOffset: function (v) { this._zIndexOffset = v },
+        dragging: {
+            enable: function () { },
+            disable: function () { },
+        },
+    }
+}
+
+function setupWithMarkerMocks() {
+    const base = setupWithLayerMocks()
+    const mockCircle = makeMockCircleMarker()
+    const mockIcon = makeMockIconMarker()
+
+    global.L.circleMarker = (latlng) => { mockCircle._latlng = latlng; return mockCircle }
+    global.L.marker = (latlng) => { mockIcon._latlng = latlng; return mockIcon }
+    global.L.icon = (opts) => ({ _iconUrl: opts.iconUrl })
+
+    return { ...base, mockCircle, mockIcon }
+}
+
+// ─── addMarker ────────────────────────────────────────────────────────────────
+
+test.describe('LeafletAdapter - addMarker', () => {
+
+    test('creates a circleMarker by default and adds it to the map', () => {
+        const { mockCircle, addedLayers } = setupWithMarkerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        const marker = adapter.addMarker({ id: 'cm', position: { lat: 10, lng: 20 } })
+
+        expect(marker).toBe(mockCircle)
+        expect(addedLayers).toContain(mockCircle)
+    })
+
+    test('creates an icon marker when icon.url is provided', () => {
+        const { mockIcon, addedLayers } = setupWithMarkerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        const marker = adapter.addMarker({
+            id: 'im',
+            position: { lat: 10, lng: 20 },
+            icon: { url: 'https://example.com/icon.png' },
+        })
+
+        expect(marker).toBe(mockIcon)
+        expect(addedLayers).toContain(mockIcon)
+    })
+
+    test('addMarker throws when id is missing', () => {
+        setupWithMarkerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        expect(() =>
+            adapter.addMarker({ position: { lat: 0, lng: 0 } })
+        ).toThrow('options.id is required')
+    })
+
+    test('addMarker throws when position is missing', () => {
+        setupWithMarkerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        expect(() =>
+            adapter.addMarker({ id: 'no-pos' })
+        ).toThrow('options.position is required')
+    })
+})
+
+// ─── removeMarker ─────────────────────────────────────────────────────────────
+
+test.describe('LeafletAdapter - removeMarker', () => {
+
+    test('removes a marker by string ID and cleans up registry', () => {
+        const { removedLayers } = setupWithMarkerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        adapter.addMarker({ id: 'rm', position: { lat: 0, lng: 0 } })
+        adapter.removeMarker('rm')
+
+        expect(removedLayers.length).toBeGreaterThan(0)
+    })
+
+    test('removing a non-existent id is a no-op', () => {
+        setupWithMarkerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        expect(() => adapter.removeMarker('ghost')).not.toThrow()
+    })
+})
+
+// ─── updateMarker ─────────────────────────────────────────────────────────────
+
+test.describe('LeafletAdapter - updateMarker', () => {
+
+    test('updates marker position', () => {
+        const { mockCircle } = setupWithMarkerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        adapter.addMarker({ id: 'mv', position: { lat: 0, lng: 0 } })
+        adapter.updateMarker('mv', { position: { lat: 5, lng: 10 } })
+
+        expect(mockCircle._latlng).toEqual([5, 10])
+    })
+
+    test('updates zIndexOffset', () => {
+        const { mockCircle } = setupWithMarkerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        adapter.addMarker({ id: 'zi', position: { lat: 0, lng: 0 } })
+        adapter.updateMarker('zi', { zIndexOffset: 999 })
+
+        expect(mockCircle._zIndexOffset).toBe(999)
+    })
+
+    test('updateMarker throws when id is not found', () => {
+        setupWithMarkerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        expect(() =>
+            adapter.updateMarker('ghost', { position: { lat: 0, lng: 0 } })
+        ).toThrow('no marker found with id "ghost"')
+    })
+
+    test('updateMarker returns the native Leaflet marker', () => {
+        const { mockCircle } = setupWithMarkerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        adapter.addMarker({ id: 'ret', position: { lat: 0, lng: 0 } })
+        const returned = adapter.updateMarker('ret', { zIndexOffset: 1 })
+
+        expect(returned).toBe(mockCircle)
+    })
+})
+
+// ─── onFeatureClick ───────────────────────────────────────────────────────────
+
+test.describe('LeafletAdapter - onFeatureClick', () => {
+
+    test('registers a click handler on the map', () => {
+        const { mockMap } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        let clickHandlerRegistered = false
+        mockMap.on = (event) => { if (event === 'click') clickHandlerRegistered = true }
+
+        adapter.onFeatureClick(() => { })
+
+        expect(clickHandlerRegistered).toBe(true)
+    })
+
+    test('calls handler with feature: null when no vector layers match', () => {
+        const { mockMap } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        let capturedResult = null
+        let clickCallback = null
+        mockMap.on = (event, cb) => { if (event === 'click') clickCallback = cb }
+
+        adapter.onFeatureClick((result) => { capturedResult = result })
+        clickCallback({ latlng: { lat: 0, lng: 0 }, containerPoint: { x: 0, y: 0 } })
+
+        expect(capturedResult.feature).toBeNull()
+    })
+})
+
+// ─── onFeatureHover ───────────────────────────────────────────────────────────
+
+test.describe('LeafletAdapter - onFeatureHover', () => {
+
+    test('registers mousemove and mouseout handlers on the map', () => {
+        const { mockMap } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        const registeredEvents = []
+        mockMap.on = (event) => registeredEvents.push(event)
+
+        adapter.onFeatureHover(() => { })
+
+        expect(registeredEvents).toContain('mousemove')
+        expect(registeredEvents).toContain('mouseout')
+    })
+
+    test('calls handler with feature: null on mouseout', () => {
+        const { mockMap } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        let capturedResult = null
+        let mouseoutCallback = null
+        mockMap.on = (event, cb) => { if (event === 'mouseout') mouseoutCallback = cb }
+
+        adapter.onFeatureHover((result) => { capturedResult = result })
+        mouseoutCallback()
+
+        expect(capturedResult.feature).toBeNull()
+    })
+})
+
+// ─── queryRenderedFeatures ────────────────────────────────────────────────────
+
+test.describe('LeafletAdapter - queryRenderedFeatures', () => {
+
+    test('returns empty array when no layers are registered', () => {
+        setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        const results = adapter.queryRenderedFeatures({ x: 0, y: 0 })
+
+        expect(results).toEqual([])
+    })
+
+    test('returns empty array when layer has no getBounds', () => {
+        setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        const results = adapter.queryRenderedFeatures({ x: 0, y: 0 }, { layers: ['tile-no-bounds'] })
+
+        expect(results).toEqual([])
+    })
+
+    test('skips layers not in options.layers filter', () => {
+        const { mockGeoJSON } = setupWithLayerMocks()
+        const adapter = new LeafletAdapter()
+        adapter.init({ containerId: 'map' })
+
+        mockGeoJSON.getBounds = () => ({ contains: () => true })
+        global.L.geoJSON = () => mockGeoJSON
+
+        adapter.createLayer({ id: 'included', type: 'vector', geojson: { type: 'FeatureCollection', features: [] } })
+
+        const results = adapter.queryRenderedFeatures({ x: 0, y: 0 }, { layers: ['other-id'] })
+
+        expect(results).toEqual([])
+    })
+})


### PR DESCRIPTION
## Purpose
Extend `LeafletAdapter.ts` to implement tile and GeoJSON layer management (`addLayer`, `createLayer`, `removeLayer`, `updateLayer`), with layer construction logic factored into a new `LeafletHelpers.ts` utility.

## Proposed Changes
- [ADD] `LeafletHelpers.ts` — layer construction utilities (`buildLeafletLayer`, `resolveLeafletLayerId`)
- [CHANGE] `LeafletAdapter.ts` — implement `createLayer`, `removeLayer`, `updateLayer`; make add`L`ayer backward-compatible. Implemented marker management (addMarker, removeMarker) and abstracted the Leaflet marker instantiation logic into helper utilities. Added map projection support (projectCoordinates, unprojectCoordinates)
- [ADD] Unit tests for all new layer methods

## Issues
- [Closes #17](https://github.com/NASA-IMPACT/MMGIS/issues/17)
- [Closes #18](https://github.com/NASA-IMPACT/MMGIS/issues/18)

## Testing
- Unit tests passed (tests/unit/LeafletAdapter.spec.js)
