### PR TITLE
chore: extend Playwright to parse TS unit test files

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
   testDir: "./tests",
 
   // Test file patterns
-  testMatch: "**/*.spec.js",
+  testMatch: "**/*.spec.{js,ts}",
 
   // Timeout per test
   timeout: 30 * 1000,


### PR DESCRIPTION
Closes: https://github.com/NASA-IMPACT/MMGIS/issues/68

The current playwright config only matches .js unit tests. I'm extending the matching logic to **/*.spec.{js,ts} so that we can benefit from types when writing tests.