### PR TITLE
feat: add  basemap support to Leaflet adapter

### DIFF
--- a/configure/src/components/Panel/Modals/NewMissionModal/NewMissionModal.js
+++ b/configure/src/components/Panel/Modals/NewMissionModal/NewMissionModal.js
@@ -118,7 +118,7 @@ const MAP_ENGINES = [
 
 const MODAL_NAME = "newMission";
 const NewMissionModal = (props) => {
-  const {} = props;
+  const { } = props;
   const c = useStyles();
 
   const modal = useSelector((state) => state.core.modal[MODAL_NAME]);
@@ -155,6 +155,7 @@ const NewMissionModal = (props) => {
 
     const config = {
       msv: {
+        view: [39, -98, 4],
         radius: {
           major: planetRadius.major,
           minor: planetRadius.minor,
@@ -163,7 +164,7 @@ const NewMissionModal = (props) => {
       },
     };
 
-    if (selectedEngine === "deckgl" && basemapProvider !== "none" && basemapStyle) {
+    if (basemapProvider !== "none" && basemapStyle) {
       config.msv.basemap = {
         provider: basemapProvider,
         style: basemapStyle,
@@ -313,7 +314,7 @@ const NewMissionModal = (props) => {
         <Typography className={c.subtitle2}>
           {`Choose the rendering engine for this mission's 2D map. This cannot be changed after the mission is created.`}
         </Typography>
-        {selectedEngine === "deckgl" && (
+        {selectedEngine !== "" && (
           <>
             <FormControl className={c.planetDropdown} variant="filled">
               <InputLabel>Basemap</InputLabel>
@@ -322,13 +323,13 @@ const NewMissionModal = (props) => {
                 onChange={(e) => setBasemapProvider(e.target.value)}
                 label="Basemap"
               >
-                <MenuItem value="none">None (transparent background)</MenuItem>
+                <MenuItem value="none">None (no basemap)</MenuItem>
                 <MenuItem value="maplibre">MapLibre GL (open-source)</MenuItem>
                 <MenuItem value="mapbox">Mapbox GL (requires access token)</MenuItem>
               </Select>
             </FormControl>
             <Typography className={c.subtitle2}>
-              {`Optional vector-tile basemap rendered beneath deck.gl layers. Can be changed later.`}
+              {`Optional vector-tile basemap rendered beneath map layers. Can be changed later.`}
             </Typography>
             {basemapProvider !== "none" && (
               <>

--- a/configure/src/metaconfigs/tab-ui-config.json
+++ b/configure/src/metaconfigs/tab-ui-config.json
@@ -76,7 +76,7 @@
         {
           "field": "msv.basemap.provider",
           "name": "Provider",
-          "description": "Renders a vector-tile basemap beneath deck.gl layers using MapboxOverlay. Has no effect on Leaflet-engine missions. 'maplibre' is open-source and requires no token. 'mapbox' requires an access token.",
+          "description": "Renders a vector-tile basemap beneath map layers using MapLibre or Mapbox GL. Works with both Leaflet and deck.gl engine missions. 'maplibre' is open-source and requires no token. 'mapbox' requires an access token.",
           "type": "dropdown",
           "options": ["none", "maplibre", "mapbox"],
           "default": "none",

--- a/src/css/mmgis.css
+++ b/src/css/mmgis.css
@@ -398,6 +398,105 @@ body {
 .leaflet-container {
     background: black;
 }
+/* When a basemap overlay is active, the Leaflet container must be transparent
+   so the MapLibre/Mapbox GL map behind it is visible. */
+.mmgis-has-basemap.leaflet-container,
+.mmgis-has-basemap .leaflet-container {
+    background: transparent !important;
+}
+/* Basemap underlay container — sits behind the Leaflet #map div */
+.mmgis-basemap-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 0;
+}
+/* Ensure the Leaflet map div sits above the basemap container */
+#map.mmgis-has-basemap,
+.mmgis-has-basemap #map {
+    position: relative;
+    z-index: 1;
+}
+/* ---- Basemap Switcher Control ---- */
+.mmgis-basemap-switcher {
+    position: absolute;
+    bottom: 72px;
+    left: 12px;
+    z-index: 1002;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    pointer-events: auto;
+}
+.mmgis-basemap-switcher-toggle {
+    width: 52px;
+    height: 52px;
+    border-radius: 4px;
+    background: var(--color-a);
+    border: 2px solid var(--color-a-5);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    transition: border-color 0.2s ease-out;
+    overflow: hidden;
+    user-select: none;
+}
+.mmgis-basemap-switcher-toggle:hover {
+    border-color: var(--color-mmgis);
+}
+.mmgis-basemap-switcher-toggle i {
+    font-size: 22px;
+    color: var(--color-a5);
+}
+.mmgis-basemap-switcher-toggle span {
+    font-size: 9px;
+    color: var(--color-a5);
+    margin-top: 2px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 48px;
+    text-align: center;
+}
+.mmgis-basemap-switcher-options {
+    display: none;
+    flex-direction: column;
+    gap: 3px;
+    background: var(--color-a);
+    border: 1px solid var(--color-a-5);
+    border-radius: 4px;
+    padding: 4px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+    max-height: 240px;
+    overflow-y: auto;
+}
+.mmgis-basemap-switcher.open .mmgis-basemap-switcher-options {
+    display: flex;
+}
+.mmgis-basemap-switcher-option {
+    padding: 6px 10px;
+    cursor: pointer;
+    border-radius: 3px;
+    font-size: 12px;
+    color: var(--color-a5);
+    white-space: nowrap;
+    transition: background 0.15s ease-out, color 0.15s ease-out;
+}
+.mmgis-basemap-switcher-option:hover {
+    background: var(--color-a1);
+    color: #fff;
+}
+.mmgis-basemap-switcher-option.active {
+    background: var(--color-o);
+    color: #fff;
+}
 .leaflet-popup-content-wrapper {
     background: var(--color-a);
     color: #e1e1e1;

--- a/src/essence/Ancillary/BasemapSwitcher.js
+++ b/src/essence/Ancillary/BasemapSwitcher.js
@@ -165,8 +165,8 @@ const BasemapSwitcher = {
 
         _container.append(options)
 
-        // Mount into mapToolBar (bottom of map area)
-        $('#mapToolBar').append(_container)
+        // Mount into mapScreen (the map's parent container)
+        $('#mapScreen').append(_container)
 
         // Close on outside click
         $(document).on('click.basemapSwitcher', function () {

--- a/src/essence/Ancillary/BasemapSwitcher.js
+++ b/src/essence/Ancillary/BasemapSwitcher.js
@@ -1,0 +1,221 @@
+/**
+ * BasemapSwitcher.js
+ *
+ * A floating UI control that lets the user switch between configured
+ * basemap styles (e.g. Streets, Satellite, Terrain) at runtime.
+ *
+ * Reads style presets from `L_.configData.msv.basemap.styles[]` and
+ * calls `Map_.engine.setBasemapStyle(url)` to apply the selected style
+ * to the underlying MapLibre/Mapbox GL basemap in both Leaflet and
+ * deck.gl adapter modes.
+ *
+ * If no styles[] array is configured, sensible defaults are generated
+ * based on the basemap provider.
+ */
+
+import $ from 'jquery'
+import L_ from '../Basics/Layers_/Layers_'
+
+let Map_ = null
+let _container = null
+let _activeIndex = 0
+
+/**
+ * Default style presets for Mapbox provider.
+ */
+const MAPBOX_DEFAULTS = [
+    { name: 'Streets', style: 'mapbox://styles/mapbox/streets-v12' },
+    { name: 'Satellite', style: 'mapbox://styles/mapbox/satellite-streets-v12' },
+    { name: 'Outdoors', style: 'mapbox://styles/mapbox/outdoors-v12' },
+    { name: 'Light', style: 'mapbox://styles/mapbox/light-v11' },
+    { name: 'Dark', style: 'mapbox://styles/mapbox/dark-v11' },
+]
+
+/**
+ * Default style presets for MapLibre provider.
+ * Uses OpenFreeMap styles which are free and require no token.
+ */
+const MAPLIBRE_DEFAULTS = [
+    { name: 'Liberty', style: 'https://tiles.openfreemap.org/styles/liberty' },
+    { name: 'Bright', style: 'https://tiles.openfreemap.org/styles/bright' },
+    { name: 'Positron', style: 'https://tiles.openfreemap.org/styles/positron' },
+]
+
+const BasemapSwitcher = {
+    /**
+     * Initialise and mount the basemap switcher control.
+     *
+     * @param {object} mapRef - Reference to the Map_ module.
+     */
+    init(mapRef) {
+        Map_ = mapRef
+
+        const basemapConfig = L_.configData?.msv?.basemap
+        if (!basemapConfig || !basemapConfig.provider || basemapConfig.provider === 'none') {
+            return
+        }
+
+        // Use configured styles, or auto-generate defaults based on provider
+        let styles = basemapConfig.styles
+        if (!styles || styles.length === 0) {
+            styles = this._getDefaultStyles(basemapConfig)
+        }
+
+        if (!styles || styles.length === 0) {
+            return
+        }
+
+        // Determine which style is initially active (match against basemap.style)
+        _activeIndex = 0
+        styles.forEach((s, i) => {
+            if (s.style === basemapConfig.style) {
+                _activeIndex = i
+            }
+        })
+
+        // Build the DOM
+        this._buildUI(styles)
+    },
+
+    /**
+     * Remove the switcher from the DOM.
+     */
+    destroy() {
+        $(document).off('click.basemapSwitcher')
+        if (_container) {
+            _container.remove()
+            _container = null
+        }
+    },
+
+    /**
+     * Generate default style presets based on the basemap provider.
+     * If the configured style URL is not in the defaults, prepend it as "Current".
+     *
+     * @param {object} basemapConfig
+     * @returns {Array<{name: string, style: string}>}
+     */
+    _getDefaultStyles(basemapConfig) {
+        let defaults
+        if (basemapConfig.provider === 'mapbox') {
+            defaults = [...MAPBOX_DEFAULTS]
+        } else {
+            defaults = [...MAPLIBRE_DEFAULTS]
+        }
+
+        // If the configured style is already in defaults, we're good.
+        const currentInDefaults = defaults.some(
+            (d) => d.style === basemapConfig.style
+        )
+
+        // If not, prepend the current style so the user can always get back to it.
+        if (!currentInDefaults && basemapConfig.style) {
+            defaults.unshift({
+                name: 'Current',
+                style: basemapConfig.style,
+            })
+        }
+
+        return defaults
+    },
+
+    /**
+     * Build and append the switcher UI.
+     * @param {Array<{name: string, style: string}>} styles
+     */
+    _buildUI(styles) {
+        // Remove previous instance if any
+        this.destroy()
+
+        const activeName = styles[_activeIndex]?.name || 'Map'
+
+        // Container
+        _container = $('<div>')
+            .addClass('mmgis-basemap-switcher')
+            .attr('id', 'mmgis-basemap-switcher')
+
+        // Toggle button
+        const toggle = $('<div>')
+            .addClass('mmgis-basemap-switcher-toggle')
+            .attr('title', 'Switch basemap style')
+            .html(
+                `<i class="mdi mdi-layers mdi-18px"></i><span>${activeName}</span>`
+            )
+            .on('click', function (e) {
+                e.stopPropagation()
+                _container.toggleClass('open')
+            })
+
+        _container.append(toggle)
+
+        // Options panel
+        const options = $('<div>').addClass('mmgis-basemap-switcher-options')
+
+        styles.forEach((styleEntry, index) => {
+            const option = $('<div>')
+                .addClass('mmgis-basemap-switcher-option')
+                .addClass(index === _activeIndex ? 'active' : '')
+                .text(styleEntry.name)
+                .on('click', function (e) {
+                    e.stopPropagation()
+                    BasemapSwitcher._selectStyle(index, styles)
+                })
+            options.append(option)
+        })
+
+        _container.append(options)
+
+        // Mount into mapToolBar (bottom of map area)
+        $('#mapToolBar').append(_container)
+
+        // Close on outside click
+        $(document).on('click.basemapSwitcher', function () {
+            if (_container) _container.removeClass('open')
+        })
+    },
+
+    /**
+     * Handle a style selection.
+     *
+     * @param {number} index
+     * @param {Array<{name: string, style: string}>} styles
+     */
+    _selectStyle(index, styles) {
+        if (index === _activeIndex) {
+            _container.removeClass('open')
+            return
+        }
+
+        _activeIndex = index
+        const selectedStyle = styles[index]
+
+        // Apply the style to the basemap
+        if (Map_ && Map_.engine) {
+            if (typeof Map_.engine.setBasemapStyle === 'function') {
+                // Leaflet adapter
+                Map_.engine.setBasemapStyle(selectedStyle.style)
+            } else if (typeof Map_.engine.getBasemap === 'function') {
+                // deck.gl adapter — setStyle on the underlying basemap
+                const basemap = Map_.engine.getBasemap()
+                if (basemap && typeof basemap.setStyle === 'function') {
+                    basemap.setStyle(selectedStyle.style)
+                }
+            }
+        }
+
+        // Update UI
+        _container
+            .find('.mmgis-basemap-switcher-option')
+            .removeClass('active')
+            .eq(index)
+            .addClass('active')
+
+        _container.find('.mmgis-basemap-switcher-toggle span').text(
+            selectedStyle.name
+        )
+
+        _container.removeClass('open')
+    },
+}
+
+export default BasemapSwitcher

--- a/src/essence/Basics/MapEngines/Adapters/LeafletAdapter.ts
+++ b/src/essence/Basics/MapEngines/Adapters/LeafletAdapter.ts
@@ -22,6 +22,7 @@ import {
     FitBoundsOptions,
     MapInitOptions,
     ProjectionOptions,
+    BasemapOptions,
 } from '../types/view'
 import { LayerOptions, TileLayerOptions, MarkerOptions } from '../types/layers'
 import { IMapEngineMarkers } from '../IMapEngineMarkers'
@@ -39,6 +40,9 @@ import {
     QueryFeaturesOptions,
 } from '../types/events'
 import { MapEngineType } from '../types/engine'
+
+import { Map as MaplibreGLMap } from 'maplibre-gl'
+import 'maplibre-gl/dist/maplibre-gl.css'
 
 // Leaflet is loaded globally via window.L
 declare const L: any
@@ -78,6 +82,27 @@ export default class LeafletAdapter implements IMapEngine<any, any, any>, IMapEn
      * Stored initialization options
      */
     private _initOptions: MapInitOptions | null = null
+
+    /**
+     * The MapLibre/Mapbox GL basemap instance (when basemap overlay is active).
+     * Renders behind the transparent Leaflet canvas.
+     */
+    private _basemapMap: any = null
+
+    /**
+     * The DOM element hosting the basemap map (sibling of the Leaflet #map div).
+     */
+    private _basemapContainer: HTMLDivElement | null = null
+
+    /**
+     * The basemap configuration passed at init time.
+     */
+    private _basemapOptions: BasemapOptions | null = null
+
+    /**
+     * Bound handler for synchronising Leaflet camera → basemap camera.
+     */
+    private _syncHandler: (() => void) | null = null
 
     /**
      * Initialize the Leaflet map instance
@@ -153,6 +178,11 @@ export default class LeafletAdapter implements IMapEngine<any, any, any>, IMapEn
         const attributionControl = this._container.querySelector('.leaflet-control-attribution')
         if (attributionControl) {
             attributionControl.remove()
+        }
+
+        // --- Basemap overlay setup ---
+        if (options.basemap && options.basemap.provider && options.basemap.provider !== 'none' as any) {
+            this._initBasemapOverlay(options.basemap, center, zoom)
         }
     }
 
@@ -247,6 +277,9 @@ export default class LeafletAdapter implements IMapEngine<any, any, any>, IMapEn
     destroy(): void {
         if (!this._map) return
 
+        // Clean up basemap overlay first
+        this._destroyBasemapOverlay()
+
         this._eventHandlers.forEach((handler, eventName) => {
             this._map.off(eventName, handler)
         })
@@ -266,6 +299,14 @@ export default class LeafletAdapter implements IMapEngine<any, any, any>, IMapEn
      */
     getNativeMap(): any {
         return this._map
+    }
+
+    /**
+     * Get the underlying MapLibre/Mapbox GL basemap instance.
+     * Returns null if no basemap is configured.
+     */
+    getBasemap(): any {
+        return this._basemapMap
     }
 
     /**
@@ -473,6 +514,7 @@ export default class LeafletAdapter implements IMapEngine<any, any, any>, IMapEn
      */
     invalidateSize(): void {
         this._map.invalidateSize()
+        this._basemapMap?.resize()
     }
 
     /**
@@ -938,5 +980,170 @@ export default class LeafletAdapter implements IMapEngine<any, any, any>, IMapEn
             }
         }
         return null
+    }
+
+    // ========================================
+    // BASEMAP OVERLAY METHODS
+    // ========================================
+
+    /**
+     * Initialise a MapLibre/Mapbox GL basemap behind the Leaflet canvas.
+     *
+     * Creates a sibling div before the Leaflet container, instantiates a
+     * MapLibre (or Mapbox) GL map inside it, makes the Leaflet container
+     * background transparent, and wires up pan/zoom sync events.
+     */
+    private _initBasemapOverlay(
+        basemap: BasemapOptions,
+        center: LatLng,
+        zoom: number
+    ): void {
+        this._basemapOptions = basemap
+
+        this._basemapContainer = document.createElement('div')
+        this._basemapContainer.id = 'mmgis-basemap'
+        this._basemapContainer.className = 'mmgis-basemap-container'
+        this._basemapContainer.style.position = 'absolute'
+        this._basemapContainer.style.top = '0'
+        this._basemapContainer.style.left = '0'
+        this._basemapContainer.style.width = '100%'
+        this._basemapContainer.style.height = '100%'
+        this._basemapContainer.style.zIndex = '0'
+
+        // Insert before the Leaflet container so it renders behind
+        this._container!.parentNode!.insertBefore(
+            this._basemapContainer,
+            this._container
+        )
+
+        // Make the Leaflet container transparent so the basemap shows through
+        this._container!.style.background = 'transparent'
+        this._container!.classList.add('mmgis-has-basemap')
+
+        // Ensure leaflet panes have transparent background
+        const tilePane = this._container!.querySelector('.leaflet-tile-pane') as HTMLElement
+        if (tilePane) {
+            tilePane.style.background = 'transparent'
+        }
+
+        // Create the basemap map instance
+        if (basemap.provider === 'mapbox') {
+            this._initBasemapMapbox(basemap, center, zoom)
+        } else {
+            // MapLibre (default)
+            this._initBasemapMaplibre(basemap, center, zoom)
+        }
+
+        // Wire up Leaflet → basemap sync
+        this._syncHandler = () => this._syncBasemap()
+        this._map.on('move', this._syncHandler)
+        this._map.on('zoomend', this._syncHandler)
+        this._map.on('resize', () => this._basemapMap?.resize())
+    }
+
+    /**
+     * Initialise a MapLibre GL basemap.
+     */
+    private _initBasemapMaplibre(
+        basemap: BasemapOptions,
+        center: LatLng,
+        zoom: number
+    ): void {
+        this._basemapMap = new MaplibreGLMap({
+            container: this._basemapContainer!,
+            style: basemap.style,
+            center: [center.lng, center.lat],
+            zoom: zoom,
+            attributionControl: false,
+            interactive: false, // Leaflet handles all interaction
+        })
+    }
+
+    /**
+     * Initialise a Mapbox GL basemap via dynamic import.
+     */
+    private async _initBasemapMapbox(
+        basemap: BasemapOptions,
+        center: LatLng,
+        zoom: number
+    ): Promise<void> {
+        try {
+            const lib = (await import('mapbox-gl')) as any
+            const MapboxMap = (lib.default ?? lib).Map
+            if (!MapboxMap) {
+                throw new Error('Map not found in mapbox-gl module')
+            }
+
+            this._basemapMap = new MapboxMap({
+                container: this._basemapContainer!,
+                style: basemap.style,
+                center: [center.lng, center.lat],
+                zoom: zoom,
+                accessToken: basemap.accessToken,
+                attributionControl: false,
+                interactive: false,
+            })
+        } catch {
+            console.error(
+                'LeafletAdapter: mapbox-gl is not installed. ' +
+                "Run `npm install mapbox-gl` or use provider: 'maplibre' instead."
+            )
+        }
+    }
+
+    /**
+     * Synchronise the basemap camera to match the current Leaflet view.
+     * Called on Leaflet `move` and `zoomend` events.
+     */
+    private _syncBasemap(): void {
+        if (!this._basemapMap) return
+
+        const center = this._map.getCenter()
+        const zoom = this._map.getZoom()
+
+        this._basemapMap.jumpTo({
+            center: [center.lng, center.lat],
+            zoom: zoom,
+        })
+    }
+
+    /**
+     * Switch the basemap to a different style at runtime.
+     * This is used by the BasemapSwitcher UI control.
+     *
+     * @param styleUrl - A MapLibre/Mapbox style URL.
+     */
+    setBasemapStyle(styleUrl: string): void {
+        if (!this._basemapMap) return
+        this._basemapMap.setStyle(styleUrl)
+    }
+
+    /**
+     * Clean up the basemap overlay: remove the GL map, its container,
+     * and restore the Leaflet container's opaque background.
+     */
+    private _destroyBasemapOverlay(): void {
+        if (this._syncHandler && this._map) {
+            this._map.off('move', this._syncHandler)
+            this._map.off('zoomend', this._syncHandler)
+            this._syncHandler = null
+        }
+
+        if (this._basemapMap) {
+            this._basemapMap.remove()
+            this._basemapMap = null
+        }
+
+        if (this._basemapContainer) {
+            this._basemapContainer.remove()
+            this._basemapContainer = null
+        }
+
+        if (this._container) {
+            this._container.style.background = ''
+            this._container.classList.remove('mmgis-has-basemap')
+        }
+
+        this._basemapOptions = null
     }
 }

--- a/src/essence/Basics/MapEngines/types/view.ts
+++ b/src/essence/Basics/MapEngines/types/view.ts
@@ -45,7 +45,7 @@ export interface FitBoundsOptions extends ViewOptions {
 }
 
 /**
- * Supported basemap providers for deck.gl overlay mode.
+ * Supported basemap providers for deck.gl and Leaflet overlay mode.
  *
  * `'maplibre'` uses MapLibre GL JS (open-source, no access token required).
  * `'mapbox'` uses Mapbox GL JS (requires a valid {@link BasemapOptions.accessToken}).
@@ -53,10 +53,30 @@ export interface FitBoundsOptions extends ViewOptions {
 export type BasemapProvider = 'mapbox' | 'maplibre'
 
 /**
- * Configuration for an optional vector-tile basemap rendered beneath deck.gl layers
- * via `@deck.gl/mapbox`'s `MapboxOverlay`. When present, the adapter runs in overlay
- * mode; when absent it falls back to a standalone `Deck` instance with a transparent
- * background.
+ * A named basemap style preset for the in-map style switcher control.
+ * Each entry maps a user-friendly display name to a MapLibre/Mapbox style URL.
+ *
+ * @example
+ * ```ts
+ * { name: 'Streets', style: 'https://demotiles.maplibre.org/style.json' }
+ * ```
+ */
+export interface BasemapStyleEntry {
+    /** Display name shown in the style switcher. */
+    name: string
+    /** MapLibre/Mapbox style URL for this entry. */
+    style: string
+}
+
+/**
+ * Configuration for an optional vector-tile basemap rendered beneath map layers
+ * for both the deck.gl and Leaflet adapters.
+ *
+ * **deck.gl**: Uses `@deck.gl/mapbox`'s `MapboxOverlay` to composite deck.gl layers
+ * on top of a MapLibre/Mapbox GL basemap.
+ *
+ * **Leaflet**: Creates a MapLibre/Mapbox GL map behind a transparent Leaflet canvas
+ * and synchronises pan/zoom events so the basemap and Leaflet layers stay aligned.
  *
  * The chosen provider's stylesheet must be imported in the application entry point:
  * `import 'maplibre-gl/dist/maplibre-gl.css'` or `import 'mapbox-gl/dist/mapbox-gl.css'`.
@@ -69,6 +89,7 @@ export interface BasemapOptions {
     provider: BasemapProvider
     /**
      * Map style URL or a Mapbox/MapLibre style JSON object URL.
+     * This is the default/initial style that the basemap loads with.
      * @example 'https://demotiles.maplibre.org/style.json'
      * @example 'mapbox://styles/mapbox/streets-v12'
      */
@@ -78,6 +99,12 @@ export interface BasemapOptions {
      * Ignored for `'maplibre'`.
      */
     accessToken?: string
+    /**
+     * Optional array of named style presets for the in-map style switcher control.
+     * When provided, a floating UI selector lets the user switch between basemap
+     * styles (e.g. Streets, Satellite, Terrain) at runtime.
+     */
+    styles?: BasemapStyleEntry[]
 }
 
 /**
@@ -102,9 +129,12 @@ export interface MapInitOptions {
     editable?: boolean
     projection?: ProjectionOptions
     /**
-     * Optional vector-tile basemap to render beneath deck.gl layers via `MapboxOverlay`.
-     * When absent the DeckGL adapter operates in standalone mode with a transparent background.
-     * Has no effect on the Leaflet adapter.
+     * Optional vector-tile basemap to render beneath map layers.
+     *
+     * - **deck.gl**: renders via `MapboxOverlay` (overlay mode).
+     * - **Leaflet**: renders a MapLibre/Mapbox GL map behind a transparent Leaflet canvas.
+     *
+     * When absent, both adapters fall back to their default (no basemap) behaviour.
      */
     basemap?: BasemapOptions
 }

--- a/src/essence/Basics/Map_/Map_.js
+++ b/src/essence/Basics/Map_/Map_.js
@@ -18,6 +18,7 @@ import { Kinds } from '../../../pre/tools'
 import DataShaders from '../../Ancillary/DataShaders'
 import calls from '../../../pre/calls'
 import TimeControl from '../TimeControl_/TimeControl'
+import BasemapSwitcher from '../../Ancillary/BasemapSwitcher'
 
 import gjv from 'geojson-validation'
 import {
@@ -305,6 +306,9 @@ let Map_ = {
         }
 
         buildToolBar()
+
+        // Mount basemap style switcher if styles are configured
+        BasemapSwitcher.init(Map_)
 
         TimeControl.updateLayersTime()
     },


### PR DESCRIPTION
### Purpose

- Enables Leaflet-engine missions to render MapLibre/Mapbox GL vector-tile basemaps, achieving feature parity with the existing deck.gl basemap support.
- A MapLibre/Mapbox GL map is rendered behind a transparent Leaflet canvas, with automatic pan/zoom synchronization so all Leaflet layers remain perfectly aligned with the basemap.
- Adds a floating Basemap Style Switcher UI control that lets users switch between basemap styles (e.g. Streets, Satellite, Outdoors) at runtime. Default style presets are auto-generated based on the selected provider (Mapbox or MapLibre/OpenFreeMap).

### Proposed Changes

[ADD] BasemapSwitcher.js — New floating UI control for switching basemap styles at runtime. Includes built-in default presets for both Mapbox (Streets, Satellite, Outdoors, Light, Dark) and MapLibre (Liberty, Bright, Positron via OpenFreeMap).
[ADD] Basemap overlay system in LeafletAdapter.ts — Adds _initBasemapOverlay(), _syncBasemap(), setBasemapStyle(), getBasemap(), and _destroyBasemapOverlay() methods for full basemap lifecycle management.
[ADD] CSS rules in mmgis.css for the basemap underlay container (.mmgis-basemap-container), transparent Leaflet background (.mmgis-has-basemap), and the Basemap Switcher control (.mmgis-basemap-switcher-*).
[ADD] BasemapStyleEntry interface and styles field to BasemapOptions in view.ts for typed style-switcher configuration.
[CHANGE] NewMissionModal.js — Basemap configuration fields (provider, style URL, access token) now appear for both Leaflet and deck.gl engine selections (previously deck.gl only).
[CHANGE] tab-ui-config.json — Updated basemap provider description to reflect support for both engine types.
[CHANGE] Map_.js — Imports and initializes BasemapSwitcher after map toolbar is built.
[FIX] BasemapSwitcher.js — Changed mount target from #mapToolBar to #mapScreen to fix the switcher being invisible due to the toolbar's pointer-events: none and overflow: hidden constraints.

### Testing

- Tested locally on macOS with npm start (development mode, hot-reloading)
- Verified Leaflet + MapLibre basemap renders correctly with pan/zoom sync
- Verified Leaflet + Mapbox basemap renders correctly with pan/zoom sync
- Verified Basemap Style Switcher UI appears and allows runtime style switching
- Verified existing deck.gl missions are unaffected
- Both main app (webpack) and configure app (npm run build) compile successfully with no new errors