### PR TITLE
Add writing-github-issues skill

### DIFF
--- a/.claude/skills/writing-github-issues/SKILL.md
+++ b/.claude/skills/writing-github-issues/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: writing-github-issues
+description: Use when authoring or filing a GitHub issue to hand work off for someone (or an agent) to pick up later — a feature, refactor, or bug that needs a scope a reviewer can verify without reading code.
+---
+
+# Writing GitHub Issues
+
+## Overview
+
+An issue has two audiences that pull in opposite directions:
+
+- A **verifier** (senior engineer, reviewer, future picker-upper) needs to judge *is this the right thing, in the right shape?* — without reading any code.
+- An **implementer** (often an agent) needs a rough map to start from.
+
+Write for both with **two layers**: a clean human-readable top, and a collapsed, commit-pinned implementation sketch underneath. Code references rot; keep them out of the top and honest about being a snapshot in the bottom.
+
+## Core principles
+
+- **Top layer is code-free.** No file paths, no line numbers, no function or symbol names. Vision, motivation, behavior, acceptance — phrased to survive refactors. A reader who has never opened the repo should understand the work and how to verify it.
+- **Bottom layer is an honest snapshot.** A collapsed `<details>` block holding the draft plan, stamped *"written as of `<short-sha>` on `<date>` — re-verify against latest."*
+- **Specificity is a liability.** The more precise the plan is now, the more wrong it gets and the more it misleads whoever picks it up. Go only as deep as is useful to *start* the task; assume the implementer re-investigates.
+- **Except real gotchas.** A genuinely hard-to-find trap is worth stating explicitly and marking — that's the knowledge re-investigation can't cheaply recover.
+- **Human owns the top, agent owns the bottom.** Vision and acceptance come from the person; current behavior, where-it-lands, and the rough plan come from you reading the code.
+- **Right-size it.** A good issue is roughly one reviewable PR. If the work sprawls across independent pieces, proactively propose a breakdown. The call is the human's — but making the suggestion is yours.
+
+## Workflow
+
+1. **Confirm it's issue-worthy** — a unit of work to hand off later, not something to just go do now.
+2. **Get the target** — which GitHub repo, and any parent issue/epic. Detect candidates from git remotes (`git remote -v`) but **confirm with the human**: forks and worktrees mean `origin` is often not the intended target.
+3. **Hand over the brain-dump prompts** — give the human `references/braindump-prompts.md` and let them ramble against it (speech-to-text is fine; tell them not to worry about order, structure, or transcription errors). The prompts cover the top layer — the human's vision.
+4. **Read the dump, then ask clarifying questions** — one at a time, only to fill real gaps. Don't re-interview what they already said.
+5. **Investigate the codebase** for the bottom layer — current behavior, where the change lands, a rough plan, real gotchas. Capture the short SHA (`git rev-parse --short HEAD`) and date for the pin.
+6. **Scope-check** — now that you know the true size, ask: is this one reviewable PR? If it sprawls, **proactively propose a breakdown** before assembling (see Right-sizing). Present it and let the human decide; if they split, run the rest of the flow per resulting issue.
+7. **Assemble** the body using `references/template.md` — top from the dump + clarifications, bottom in the collapsed pinned block.
+8. **Self-lint** (below) before writing.
+9. **Write to disk** at `docs/superpowers/issues/YYYY-MM-DD-<topic>.md` as an editing buffer, and tell the human to edit it directly.
+10. **File it** — once they're happy, create the issue from the edited file with `gh` (see Filing). Confirm first; it's outward-facing and not easily undone. Report the issue URL.
+
+## Right-sizing (push back on issues that are too big)
+
+A single issue should land as one PR a reviewer can hold in their head. When the scope-check (step 6) trips one of these signals, say so and propose a split:
+
+- It bundles **multiple independent capabilities** a user would describe separately.
+- It touches **several subsystems that could each ship and be reverted on their own.**
+- The **acceptance list covers unrelated outcomes** — passing one tells you nothing about another.
+- The draft plan has **pieces with no shared code** that could be built and reviewed independently.
+- The resulting **PR would be too large to review carefully** in one sitting.
+
+How to propose the breakdown:
+
+- Name the **seams** — the independent pieces, in plain language.
+- Offer a shape: either a **parent/epic + child issues**, or a **sequence** where each builds on the last.
+- Recommend **what ships first** — the smallest slice that delivers real value.
+- **Defer to the human.** Make the case, then let them decide; keeping it whole is a legitimate choice. If they split, write each issue through the normal flow (child issues can reference the parent).
+
+Frame it as a question, not a veto: *"This is really three things — A, B, C. I'd file A first as the smallest useful slice and track B/C under a parent. Want me to split it, or keep it as one?"*
+
+## Self-lint (run on the draft before writing the file)
+
+- Scan the **top** section for any file path, line number, function/symbol name, or "the X module." Found one? Delete it or move it into the collapsed plan.
+- The top reads standalone — verifiable without the code.
+- The collapsed plan is **pinned** (short SHA + date) and carries the **"rough guide, re-verify"** disclaimer.
+- Any hard-to-find gotcha is marked; the plan isn't over-specified past what's useful to start.
+
+## Filing
+
+The agent files directly with the GitHub CLI — no wrapper script, so nothing lags `gh`'s evolving sub-issue support.
+
+```bash
+gh issue create --repo <owner/repo> --title "<title>" --body-file docs/superpowers/issues/<file>.md
+```
+
+Link a parent issue/epic with whatever `gh` supports at the time (a sub-issue relationship if available; otherwise a `Parent: #N` reference in the body or a task-list entry on the parent). Check `gh issue --help` rather than assuming a flag exists.
+
+## Common mistakes
+
+- **Code references creep into the top.** They feel helpful and rot fastest. The self-lint exists to catch this — run it.
+- **Over-specifying the plan.** A precise plan that's three commits stale misleads more than a vague one. Resist.
+- **Interviewing before the dump.** Let the human brain-dump first; questions come after, and only for gaps.
+- **Filing to `origin` by reflex.** Confirm the repo — forks and worktrees make `origin` unreliable.
+- **Filing without showing the human.** The on-disk file is theirs to edit first; creating the issue is the final, confirmed step.
+- **Letting a mega-issue through.** If it's really three PRs, say so and propose a split before assembling. Silence here ships an unreviewable PR later.
+
+## Worked example
+
+`references/example-top-vs-buried.md` shows the same real issue with code-rot up top (wrong) versus a vision-level top and the detail relocated into the collapsed plan (right).

--- a/.claude/skills/writing-github-issues/references/braindump-prompts.md
+++ b/.claude/skills/writing-github-issues/references/braindump-prompts.md
@@ -1,0 +1,28 @@
+# Brain-dump prompts
+
+Hand this to the human and let them talk freely against it. This is the *input* scaffold — it feeds the human-readable top of the issue. The agent fills the implementation half by reading the code.
+
+**Tell them:** Ramble. Speech-to-text is fine. Don't worry about order, structure, grammar, or transcription errors — just react to the prompts and say what you're thinking. Skip any that don't apply. You can answer in one stream; I'll read it and ask follow-ups only where something's missing.
+
+---
+
+**Why does this matter?**
+What's broken, missing, or annoying without it? Who feels the pain, and when? What goes wrong today?
+
+**When it works, walk me through it.**
+Describe the end state as if it already exists. What does someone see or experience? What's the moment that tells you "yes, this is working"?
+
+**How does someone interact with it?**
+The concrete handles — e.g. how do you turn it on, how do you block someone, how do you edit it, what happens when you get it wrong? Talk through the interactions, not the implementation.
+
+**How would you know it's done?**
+What would you check to be satisfied? What are the must-pass cases? Any edge cases that would embarrass us if missed?
+
+**What is this explicitly NOT?**
+What's tempting to fold in but should stay out of scope? Where's the line?
+
+**(Optional) Anything you already know about the code?**
+A file, a tricky bit, a past attempt, a gotcha you remember. Just a seed — I'll investigate from here. Don't feel obligated; this half is my job.
+
+**(Targeting) Where does this go?**
+Which repo should it be filed in, and is there a parent issue or epic it belongs under?

--- a/.claude/skills/writing-github-issues/references/example-top-vs-buried.md
+++ b/.claude/skills/writing-github-issues/references/example-top-vs-buried.md
@@ -1,0 +1,47 @@
+# Worked example: top-level vision vs. buried detail
+
+A real draft (the "block saving a configuration with invalid field values" issue) started with its **current behavior described up top, full of file paths and line numbers**. That's the most common failure this skill prevents. Below: the same content the wrong way, then the right way.
+
+## ❌ Before — code-rot in the top half
+
+> ## Current behavior
+>
+> - Inline field validation exists. `Maker.js` computes a per-field format error and renders it:
+>   - `configure/src/core/Maker.js:421` — `const formatError = hasError ? "" : getFieldFormatError(...)`
+>   - Rendered as MUI `error` + `helperText` (e.g. `Maker.js:470-471`).
+> - A `validationErrors` store slice exists but is unused for gating:
+>   - `configure/src/core/ConfigureStore.js:22` — `validationErrors: []`
+>   - `SaveBar.js:88` — `saveDisabled` is gated only by `lockConfig`.
+
+**Why it's wrong:** a reviewer can't tell *what should change or why* without decoding the code. Every line number is a future lie — the moment someone edits `Maker.js`, `:421` points at something else, and the issue now misleads. The verifier audience is unserved.
+
+## ✅ After — vision up top, detail collapsed and pinned
+
+> ## Motivation
+>
+> A trusted admin types what they think is a valid link, gets no real stop, saves, and ships a dead card. The failure is invisible until someone clicks it. We already detect the bad value — we just don't act on it.
+>
+> ## How it should work
+>
+> When a configuration holds an invalid field value, saving is **blocked** with a clear, specific message that names what to fix. The block triggers even when the bad field is inside a collapsed editor the admin never opened. The existing inline red underline stays as a live hint while typing; this adds the hard stop.
+>
+> ## Done when
+>
+> - [ ] Finishing an editor that has an invalid field is blocked until it's fixed.
+> - [ ] Saving with an invalid value anywhere is blocked, even in an unopened editor.
+> - [ ] A valid value clears the block.
+>
+> <details>
+> <summary>Draft implementation plan — written as of a1b2c3d on 2026-06-08. Rough guide; re-verify against latest code.</summary>
+>
+> ### Current behavior
+> Inline validation already exists (`Maker.js` computes a per-field format error and renders it as MUI `error`/`helperText`). A `validationErrors` store slice exists but nothing gates on it — `SaveBar` disables save only on the concurrent-edit lock.
+>
+> ### Rough plan
+> Connect the existing per-field validator to the save path; add a whole-config walk so collapsed editors are covered.
+>
+> > ⚠️ Gotcha: tool field schemas are fetched async — validation that runs in the reducer needs them already loaded, or it silently passes everything. Run at save-time if that's simpler.
+>
+> </details>
+
+**Why it's right:** the top is verifiable by anyone, survives refactors, and reads as intent. The fragile detail lives in the collapsed block, pinned to a commit and flagged as a snapshot — and the one genuinely non-obvious trap (async schema load) is called out where it won't get lost.

--- a/.claude/skills/writing-github-issues/references/template.md
+++ b/.claude/skills/writing-github-issues/references/template.md
@@ -1,0 +1,58 @@
+# Issue template
+
+The *output* shape. Headings in the top half are a **default, not a cage** — deviate when the issue calls for it, but keep the top code-free and keep the plan collapsed and pinned.
+
+Copy from the line below, fill it in, drop empty sections.
+
+---
+
+```markdown
+# <Imperative title, scoped> — e.g. "Configure: block saving a configuration with invalid field values"
+
+## Motivation
+
+<Why this matters / what's broken without it. The pain, who feels it, when. No code references.>
+
+## How it should work
+
+<The vision: what it looks like when it works, and how someone interacts with it —
+how you turn it on, block someone, edit it, what happens on bad input. Behavior, not implementation.>
+
+## Done when
+
+<Acceptance criteria a verifier can check by using the thing, not by reading code.>
+
+- [ ] ...
+- [ ] ...
+
+## Out of scope
+
+<What's tempting to fold in but stays out. Where the line is.>
+
+<details>
+<summary>Draft implementation plan — written as of <short-sha> on <YYYY-MM-DD>. Rough guide; re-verify against latest code.</summary>
+
+### Current behavior
+
+<How it works today, where the relevant logic lives. Code references belong HERE, not above.>
+
+### Where the change lands & rough plan
+
+<The pieces, in enough depth to *start* — not a spec. The implementer re-investigates.>
+
+> ⚠️ Gotcha: <a genuinely hard-to-find trap worth stating explicitly, if any. Delete if none.>
+
+### References
+
+<Optional: a few key files/functions as starting points, understood to be snapshot-accurate only.>
+
+</details>
+```
+
+---
+
+## Notes for the agent
+
+- The top half comes from the human's brain dump + your clarifying questions. The collapsed half comes from your codebase investigation.
+- Get the short SHA with `git rev-parse --short HEAD` and stamp it into the `<summary>` line. The human can see and edit it in the on-disk file before filing.
+- Run the self-lint (in `SKILL.md`) before writing the file — the most common failure is code references leaking into the top half.

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,8 @@ sessions
 
 .mcp.json
 .serena
-.claude
+.claude/*
+!.claude/skills/
 .playwright-mcp
 
 # Playwright Test Artifacts


### PR DESCRIPTION
## What

Adds a `writing-github-issues` skill for authoring GitHub issues that serve two audiences at once:

- A **code-free, human-readable top** — vision, motivation, behavior, and acceptance criteria a verifier can check without reading code, phrased to survive refactors.
- A **collapsed, commit-pinned implementation sketch** — an honest snapshot (short SHA + date, "re-verify against latest") giving an implementer a place to start without over-specifying.

The skill ships with brain-dump prompts (to pull the vision out of the human), an output template, and a worked example contrasting code-rot-up-top vs. a clean top with detail relocated. It also walks the full workflow: confirm target repo, brain-dump, clarify gaps, investigate the codebase, scope-check (push back on mega-issues), assemble, self-lint, and file with `gh`.

A small `.gitignore` change un-ignores `.claude/skills/` so the skill is tracked while the rest of `.claude/` stays local.

## Example output

NASA-IMPACT/MMGIS#116 was authored with this skill — a representative example of the two-layer structure it produces.