### PR TITLE
fix(card): add required upload subdir + svg/link config

### DIFF
--- a/configure/public/toolConfigs.json
+++ b/configure/public/toolConfigs.json
@@ -293,8 +293,9 @@
                                 {
                                     "field": "image",
                                     "name": "Image",
-                                    "description": "Upload an image (png/jpg/webp/gif, &le;5MB). It is cropped to a square in the card.",
+                                    "description": "Upload an image (png/jpg/webp/gif/svg, &le;5MB). It is cropped to a square in the card.",
                                     "type": "upload",
+                                    "subdir": "CardPlugin",
                                     "width": 12
                                 },
                                 {
@@ -314,7 +315,7 @@
                                 {
                                     "field": "linkUrl",
                                     "name": "Link URL",
-                                    "description": "URL opened when the card is clicked.",
+                                    "description": "Link opened when the card is clicked. Use a full https:// URL for external sites, or start with / for a page in this site.",
                                     "type": "text",
                                     "width": 12
                                 }


### PR DESCRIPTION
## Summary

Small follow-up to the Card plugin (#103, merged in #111). Three config edits to the Card tool's image upload field in `configure/public/toolConfigs.json` that were left uncommitted and never made it into the merge.

## The fix that matters

The image upload field was merged **without a `subdir`**, which the generic upload field requires on both ends:
- Frontend: `configure/src/core/components/UploadField.js` bails with *"Upload field is missing a 'subdir' in its config."* before the request is even sent.
- Backend: `API/Backend/Upload/uploadRouter.js` requires and validates `subdir`; files land under `Missions/<mission>/<subdir>/uploads/`.

**Result:** on current `development`, uploading a card image fails. This PR sets `subdir: "CardPlugin"` to fix it.

## Help-text alignment (no behavior change)

- Note `svg` in the accepted image types — already allowed by the picker (`accept="...image/svg+xml"`) and the backend allow-list (`validate.js`); the text was just stale.
- Clarify the link field accepts a full `https://` URL or a site-relative `/` path.

## Diff

3 lines in one file:

```
+ "description": "Upload an image (png/jpg/webp/gif/svg, &le;5MB)..."
+ "subdir": "CardPlugin",
+ "description": "Link opened when the card is clicked. Use a full https:// URL..."
```

## Verification

- `subdir` requirement confirmed in `UploadField.js:34` and `uploadRouter.js:46`.
- svg acceptance confirmed in `UploadField.js:106` and `validate.js` (`image/svg+xml -> svg`).
- File validated as well-formed JSON.