### PR TITLE
Fix the stale unit tests revealed by the jsdom/Vitest migration

### DIFF
--- a/src/essence/mmgisAPI/__mocks__/mmgisAPI.js
+++ b/src/essence/mmgisAPI/__mocks__/mmgisAPI.js
@@ -3,6 +3,17 @@
 //
 // PanelManager_ imports mmgisAPI, which transitively pulls in the entire Map_
 // rendering stack. The panel specs only exercise panel logic, so this stub
-// stands in with a no-op event bus and keeps the import graph light.
-export const mmgisAPI = { emit: () => {} }
+// stands in with a real mitt event bus (matching the production API, which
+// also backs emit/on with mitt) and keeps the import graph light. Using a real
+// bus lets the panel specs subscribe with mmgisAPI.on(...) and observe the
+// layout-changed notifications the manager emits.
+import mitt from 'mitt'
+
+const events = mitt()
+
+export const mmgisAPI = {
+    emit: events.emit,
+    on: events.on,
+    off: events.off,
+}
 export const mmgisAPI_ = {}

--- a/tests/unit/DashboardConfigValidator.spec.js
+++ b/tests/unit/DashboardConfigValidator.spec.js
@@ -154,7 +154,6 @@ test.describe('DashboardConfigValidator', () => {
             const result = validateModernConfig(config);
             expect(result.valid).toBe(false);
             expect(result.errors).toContain('Tool[1] must have a string "name"');
-            expect(result.errors).toContain('Tool[1] must have a string "icon"');
         });
     });
 });

--- a/tests/unit/panelManager/panelManager.layout.spec.js
+++ b/tests/unit/panelManager/panelManager.layout.spec.js
@@ -6,7 +6,7 @@ import { test, expect, vi } from 'vitest'
 vi.mock('../../../src/essence/mmgisAPI/mmgisAPI')
 import { PanelManager } from '../../../src/essence/Basics/PanelManager_/PanelManager_.ts'
 import { PANEL_POSITION } from '../../../src/essence/Basics/PanelManager_/types/layout.ts'
-import { createMockPanelConfig, mockWindowDispatchEvent, setupWindowEnvironment } from './testHelpers.js'
+import { createMockPanelConfig, mockLayoutChangedEvents, setupWindowEnvironment } from './testHelpers.js'
 
 test.describe('PanelManager - Layout', () => {
     let panelManager
@@ -93,7 +93,7 @@ test.describe('PanelManager - Layout', () => {
             })
             panelManager.registerPanel(config)
 
-            const mock = mockWindowDispatchEvent()
+            const mock = mockLayoutChangedEvents()
 
             panelManager.resizePanel('test-panel', 300)
 
@@ -132,7 +132,7 @@ test.describe('PanelManager - Layout', () => {
 
     test.describe('notifyLayoutChanged', () => {
         test('dispatches custom event with panel data', () => {
-            const mock = mockWindowDispatchEvent()
+            const mock = mockLayoutChangedEvents()
 
             const config = createMockPanelConfig()
             panelManager.registerPanel(config)
@@ -150,7 +150,7 @@ test.describe('PanelManager - Layout', () => {
         })
 
         test('includes all panels sorted by priority in event', () => {
-            const mock = mockWindowDispatchEvent()
+            const mock = mockLayoutChangedEvents()
 
             const config1 = createMockPanelConfig({ id: 'panel-1', priority: 2 })
             const config2 = createMockPanelConfig({ id: 'panel-2', priority: 0 })

--- a/tests/unit/panelManager/panelManager.registration.spec.js
+++ b/tests/unit/panelManager/panelManager.registration.spec.js
@@ -6,7 +6,7 @@ import { test, expect, vi } from 'vitest'
 vi.mock('../../../src/essence/mmgisAPI/mmgisAPI')
 import { PanelManager } from '../../../src/essence/Basics/PanelManager_/PanelManager_.ts'
 import { PANEL_STATE } from '../../../src/essence/Basics/PanelManager_/types/layout.ts'
-import { createMockPanelConfig, mockWindowDispatchEvent, setupWindowEnvironment } from './testHelpers.js'
+import { createMockPanelConfig, mockLayoutChangedEvents, setupWindowEnvironment } from './testHelpers.js'
 
 test.describe('PanelManager - Registration', () => {
     let panelManager
@@ -81,7 +81,7 @@ test.describe('PanelManager - Registration', () => {
         })
 
         test('triggers layout recalculation after registration', () => {
-            const mock = mockWindowDispatchEvent()
+            const mock = mockLayoutChangedEvents()
             const config = createMockPanelConfig()
 
             panelManager.registerPanel(config)
@@ -113,7 +113,7 @@ test.describe('PanelManager - Registration', () => {
             const config = createMockPanelConfig()
             panelManager.registerPanel(config)
 
-            const mock = mockWindowDispatchEvent()
+            const mock = mockLayoutChangedEvents()
 
             panelManager.unregisterPanel('test-panel')
 

--- a/tests/unit/panelManager/panelManager.stateManagement.spec.js
+++ b/tests/unit/panelManager/panelManager.stateManagement.spec.js
@@ -6,7 +6,7 @@ import { test, expect, vi } from 'vitest'
 vi.mock('../../../src/essence/mmgisAPI/mmgisAPI')
 import { PanelManager } from '../../../src/essence/Basics/PanelManager_/PanelManager_.ts'
 import { PANEL_STATE } from '../../../src/essence/Basics/PanelManager_/types/layout.ts'
-import { createMockPanelConfig, createMockToolMetadata, mockWindowDispatchEvent, setupWindowEnvironment } from './testHelpers.js'
+import { createMockPanelConfig, createMockToolMetadata, mockLayoutChangedEvents, setupWindowEnvironment } from './testHelpers.js'
 
 test.describe('PanelManager - State Management', () => {
     let panelManager
@@ -40,7 +40,7 @@ test.describe('PanelManager - State Management', () => {
         })
 
         test('triggers layout recalculation after state change', () => {
-            const mock = mockWindowDispatchEvent()
+            const mock = mockLayoutChangedEvents()
 
             panelManager.setPanelState('test-panel', PANEL_STATE.COLLAPSED)
 
@@ -149,7 +149,7 @@ test.describe('PanelManager - State Management', () => {
         })
 
         test('triggers layout recalculation', () => {
-            const mock = mockWindowDispatchEvent()
+            const mock = mockLayoutChangedEvents()
 
             panelManager.focusTool('test-panel', 'test-tool')
 

--- a/tests/unit/panelManager/panelManager.toolManagement.spec.js
+++ b/tests/unit/panelManager/panelManager.toolManagement.spec.js
@@ -7,7 +7,7 @@ vi.mock('../../../src/essence/mmgisAPI/mmgisAPI')
 import { PanelManager } from '../../../src/essence/Basics/PanelManager_/PanelManager_.ts'
 import { PANEL_STATE } from '../../../src/essence/Basics/PanelManager_/types/layout.ts'
 import { TOOL_ORIENTATION } from '../../../src/essence/Basics/ToolController_/types/tool.ts'
-import { createMockPanelConfig, createMockToolMetadata, mockWindowDispatchEvent, setupWindowEnvironment } from './testHelpers.js'
+import { createMockPanelConfig, createMockToolMetadata, mockLayoutChangedEvents, setupWindowEnvironment } from './testHelpers.js'
 
 test.describe('PanelManager - Tool Management', () => {
     let panelManager
@@ -209,7 +209,7 @@ test.describe('PanelManager - Tool Management', () => {
             const toolMetadata = createMockToolMetadata()
             panelManager.addToolToPanel('test-panel', toolMetadata)
 
-            const mock = mockWindowDispatchEvent()
+            const mock = mockLayoutChangedEvents()
 
             panelManager.removeToolFromPanel('test-panel', 'test-tool')
 

--- a/tests/unit/panelManager/testHelpers.js
+++ b/tests/unit/panelManager/testHelpers.js
@@ -1,6 +1,7 @@
 import { PANEL_POSITION, PANEL_STATE, PANEL_LAYOUT_TYPE } from '../../../src/essence/Basics/PanelManager_/types/layout.ts'
 import { TOOL_ORIENTATION } from '../../../src/essence/Basics/ToolController_/types/tool.ts'
 import { mmgisAPI } from '../../../src/essence/mmgisAPI/mmgisAPI'
+import { onTestFinished } from 'vitest'
 
 const LAYOUT_CHANGED_EVENT = 'mmgis-panel-layout-changed'
 
@@ -55,6 +56,9 @@ export function mockLayoutChangedEvents() {
     }
 
     mmgisAPI.on(LAYOUT_CHANGED_EVENT, handler)
+    // Auto-unsubscribe when the current test ends, so a forgotten restore()
+    // cannot leak this handler onto the shared singleton bus.
+    onTestFinished(() => mmgisAPI.off(LAYOUT_CHANGED_EVENT, handler))
 
     return {
         events,

--- a/tests/unit/panelManager/testHelpers.js
+++ b/tests/unit/panelManager/testHelpers.js
@@ -1,5 +1,8 @@
 import { PANEL_POSITION, PANEL_STATE, PANEL_LAYOUT_TYPE } from '../../../src/essence/Basics/PanelManager_/types/layout.ts'
 import { TOOL_ORIENTATION } from '../../../src/essence/Basics/ToolController_/types/tool.ts'
+import { mmgisAPI } from '../../../src/essence/mmgisAPI/mmgisAPI'
+
+const LAYOUT_CHANGED_EVENT = 'mmgis-panel-layout-changed'
 
 /**
  * Create a basic mock panel configuration for testing
@@ -34,31 +37,29 @@ export function createMockToolMetadata(overrides = {}) {
 }
 
 /**
- * Mock window.dispatchEvent for testing layout changes
+ * Capture panel layout-changed notifications fired over the in-app event bus.
+ *
+ * PanelManager_ broadcasts layout changes via mmgisAPI.emit (mitt), not a
+ * window event. This subscribes to that bus and collects each notification,
+ * normalizing them to the shape the panel specs assert on:
+ *   { type: 'mmgis-panel-layout-changed', detail: { panels } }
  */
-export function mockWindowDispatchEvent() {
+export function mockLayoutChangedEvents() {
     const events = []
 
-    // Ensure global window object exists
-    if (typeof global.window === 'undefined') {
-        global.window = {}
+    const handler = (payload) => {
+        events.push({
+            type: LAYOUT_CHANGED_EVENT,
+            detail: payload,
+        })
     }
 
-    const originalDispatchEvent = global.window.dispatchEvent
-
-    global.window.dispatchEvent = (event) => {
-        events.push(event)
-        return true
-    }
+    mmgisAPI.on(LAYOUT_CHANGED_EVENT, handler)
 
     return {
         events,
         restore: () => {
-            if (originalDispatchEvent) {
-                global.window.dispatchEvent = originalDispatchEvent
-            } else {
-                delete global.window.dispatchEvent
-            }
+            mmgisAPI.off(LAYOUT_CHANGED_EVENT, handler)
         },
     }
 }


### PR DESCRIPTION
## What this does

Fixes the 9 stale unit tests that #150 (the Vitest + jsdom migration) left red by design. With the unit suite finally running, these previously-dead specs execute and fail — not because of the migration, but because they were written against older behavior and never ran to catch the drift. This brings them in line with the code's current behavior so the suite is honestly green.

Implements #149. Stacked on #150 (`tests-jsdom`).

## Changes

**Test content only — no production source changed.**

- **8 panel-manager specs** asserted on a removed `window.dispatchEvent`. The app now broadcasts panel-layout changes over the in-app mitt event bus (`mmgisAPI.emit('mmgis-panel-layout-changed', { panels })`), so the old listener observed nothing. They now subscribe to the bus and assert the notification fires (and, where applicable, that the `{ panels }` payload is present and sorted by priority). The shared `__mocks__/mmgisAPI.js` stub (added by #150) is upgraded from a no-op to a real `mitt()` instance so specs can subscribe to it.
- **1 validator spec** over-asserted a required `icon`. Resolved deliberately: **a tool icon is optional.** `getValidIconClass` (`ToolMetadataUtils.js`) falls back to a default icon and only warns when one is missing, and the modern UI renders every tool through it — so the runtime tolerates a missing icon by design. The over-assertion is dropped and `DashboardConfigValidator.js` is left unchanged (keeping this a test-only PR).

The producer (`PanelManager_.ts`) is intentionally **not** changed — the mitt bus is the current, correct mechanism; reintroducing a window event would be the wrong fix.

## Result

`npx vitest run` → **669 passed (38 files), 0 failures.** The unit suite is fully green; combined with #150, CI's unit leg goes green once both land.

## Notes for reviewers

- Split deliberately from #150 to keep each PR small (migration mechanics vs. stale-test content).
- **Merge order:** this stacks on #150 — merge #150 then this (or together). #150's unit CI is red by design until this lands.
